### PR TITLE
Database Migration with Foreign Key Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed foreign key constraint errors when exporting child tables with filters on intermediate tables. Filters from intermediate tables are now correctly included in JOIN clauses. ([#3](https://github.com/riseshia/exwiw/pull/3))
+
 ## [0.1.3] - 2025-04-02
 
 ### Fixed

--- a/lib/exwiw/query_ast.rb
+++ b/lib/exwiw/query_ast.rb
@@ -20,7 +20,9 @@ module Exwiw
           join_table_name: join_table_name,
           primary_key: primary_key,
         }
-        hash[:where_clauses] = where_clauses.map(&:to_h) if where_clauses.size.positive?
+        if where_clauses.size.positive?
+          hash[:where_clauses] = where_clauses.map { |wc| wc.is_a?(String) ? wc : wc.to_h }
+        end
         hash
       end
     end

--- a/lib/exwiw/query_ast_builder.rb
+++ b/lib/exwiw/query_ast_builder.rb
@@ -61,6 +61,11 @@ module Exwiw
           )
         end
 
+        # Add filter from intermediate table to join clause
+        if to_table.filter
+          join_clause.where_clauses.push to_table.filter
+        end
+
         join_clauses.push(join_clause)
       end
 

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -88,13 +88,17 @@ RSpec.describe Exwiw::QueryAstBuilder do
           { name: 'updated_at' },
           { name: 'created_at' },
         ])
-        expect(built_query_ast.join_clauses.map(&:to_h)).to eq([{
-          base_table_name: 'order_items',
-          foreign_key: 'order_id',
-          join_table_name: 'orders',
-          primary_key: 'id',
-          where_clauses: [{ column_name: 'shop_id', operator: :eq, value: [1] }] },
-        ])
+        # Verify join clause includes both the foreign key condition and the filter from orders table
+        join_clauses = built_query_ast.join_clauses.map(&:to_h)
+        expect(join_clauses.size).to eq(1)
+        expect(join_clauses[0][:base_table_name]).to eq('order_items')
+        expect(join_clauses[0][:foreign_key]).to eq('order_id')
+        expect(join_clauses[0][:join_table_name]).to eq('orders')
+        expect(join_clauses[0][:primary_key]).to eq('id')
+        # The where_clauses should contain both the shop_id condition and the filter string
+        expect(join_clauses[0][:where_clauses].size).to eq(2)
+        expect(join_clauses[0][:where_clauses][0]).to eq({ column_name: 'shop_id', operator: :eq, value: [1] })
+        expect(join_clauses[0][:where_clauses][1]).to eq('orders.id > 2')
         expect(built_query_ast.where_clauses.map(&:to_h)).to eq([])
       end
     end
@@ -112,13 +116,17 @@ RSpec.describe Exwiw::QueryAstBuilder do
           { name: 'updated_at' },
           { name: 'created_at' },
         ])
-        expect(built_query_ast.join_clauses.map(&:to_h)).to eq([{
-          base_table_name: 'transactions',
-          foreign_key: 'order_id',
-          join_table_name: 'orders',
-          primary_key: 'id',
-          where_clauses: [{ column_name: 'shop_id', operator: :eq, value: [1] }] },
-        ])
+        # Verify join clause includes both the foreign key condition and the filter from orders table
+        join_clauses = built_query_ast.join_clauses.map(&:to_h)
+        expect(join_clauses.size).to eq(1)
+        expect(join_clauses[0][:base_table_name]).to eq('transactions')
+        expect(join_clauses[0][:foreign_key]).to eq('order_id')
+        expect(join_clauses[0][:join_table_name]).to eq('orders')
+        expect(join_clauses[0][:primary_key]).to eq('id')
+        # The where_clauses should contain both the shop_id condition and the filter string
+        expect(join_clauses[0][:where_clauses].size).to eq(2)
+        expect(join_clauses[0][:where_clauses][0]).to eq({ column_name: 'shop_id', operator: :eq, value: [1] })
+        expect(join_clauses[0][:where_clauses][1]).to eq('orders.id > 2')
         expect(built_query_ast.where_clauses.map(&:to_h)).to eq([])
       end
     end


### PR DESCRIPTION
When exporting data with filters on intermediate tables (like orders.id > 2), the JOIN clauses for related tables (order_items, transactions) were not including these filters. This caused foreign key constraint violations when importing data, as child records referenced parent records that were excluded by the filter.

The fix adds filters from intermediate tables to their JOIN clauses, ensuring that only valid child records are exported.

Changes:
- lib/exwiw/query_ast_builder.rb: Add filter from intermediate tables to JOIN where_clauses
- spec/query_ast_builder_spec.rb: Update tests to verify filters are included in JOINs

This fixes the MySQL scenario test CI failure where order_items insertion failed with "Cannot add or update a child row: a foreign key constraint fails".

Generated with [Claude Code](https://claude.com/claude-code)