### PR TITLE
Fix MySQL host access for local rspec runs

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,8 +3,8 @@ services:
     image: mysql:9
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: exwiw_test
-      MYSQL_PWD: rootpassword
     ports:
       - "3306:3306"
     volumes:

--- a/scenario/test_with_mysql2.sh
+++ b/scenario/test_with_mysql2.sh
@@ -11,7 +11,7 @@ if [ -n "$CI" ]; then
   MYSQL_CMD="mysql -h 127.0.0.1 -P 3306 -u root -prootpassword"
 else
   # Local environment: use docker compose exec
-  MYSQL_CMD="docker compose exec -T mysql mysql -u root"
+  MYSQL_CMD="docker compose exec -T mysql mysql -u root -prootpassword"
 fi
 
 # Clean up

--- a/script/generate_test_seeds.sh
+++ b/script/generate_test_seeds.sh
@@ -14,13 +14,13 @@ sqlite3 tmp/seed.sqlite3 ".dump" > seed/sqlite3-dump.sql
 
 export DATABASE_NAME="exwiw_seed"
 
-docker compose exec mysql mysql -u root -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}; CREATE DATABASE ${DATABASE_NAME};"
+docker compose exec mysql mysql -u root -prootpassword -e "DROP DATABASE IF EXISTS ${DATABASE_NAME}; CREATE DATABASE ${DATABASE_NAME};"
 
 bundle exec ruby script/define_schema.rb "mysql2"
-docker compose exec mysql mysqldump -u root \
+docker compose exec mysql mysqldump -u root -prootpassword \
   --no-data "${DATABASE_NAME}" > seed/mysql2-schema.sql
 bundle exec ruby script/generate_data.rb "mysql2"
-docker compose exec mysql mysqldump -u root \
+docker compose exec mysql mysqldump -u root -prootpassword \
  "${DATABASE_NAME}" > seed/mysql2-dump.sql
 
 ## PostgreSQL

--- a/spec/support/bootstrap_databases.rb
+++ b/spec/support/bootstrap_databases.rb
@@ -43,7 +43,7 @@ module BootstrapDatabases
       raise "Failed to setup mysql2 database" unless ret
     else
       # In local development, use docker compose
-      ret = system("docker compose exec -T mysql mysql -u #{username} #{database_name} < seed/mysql2-dump.sql")
+      ret = system("docker compose exec -T mysql mysql -u #{username} -p#{password} #{database_name} < seed/mysql2-dump.sql")
       raise "Failed to setup mysql2 database" unless ret
     end
   end


### PR DESCRIPTION
## Summary
- `compose.yml` の MySQL コンテナにホストマシン (Docker Desktop の host gateway IP, e.g. `192.168.65.1`) からの接続が拒否されていたため、`MYSQL_ROOT_HOST: '%'` を追加して `root@%` を作成するようにしました。
- 同時に、MySQL 9 の entrypoint 初期化フェーズと衝突して `Access denied for user 'root'@'localhost'` を引き起こしていた `MYSQL_PWD: rootpassword` を削除しました（`--initialize-insecure` で空パスワードの root が作られた直後に entrypoint が `MYSQL_PWD` を使って認証しようとして失敗するため）。
- `MYSQL_PWD` の削除に伴い、`docker compose exec mysql mysql ...` 系で暗黙にパスワードが渡らなくなるため、`spec/support/bootstrap_databases.rb` / `scenario/test_with_mysql2.sh` / `script/generate_test_seeds.sh` の各コマンドに `-prootpassword` を明示的に追加しました。

## Background
ローカルで `bundle exec rspec` を実行すると以下のエラーで失敗していました:
```
Mysql2::Error: Host '192.168.65.1' is not allowed to connect to this MySQL server
```

## Test plan
- [x] `docker compose down -v && docker compose up -d` でボリュームを作り直して再現確認
- [x] `bundle exec rspec` がローカル (macOS + Docker Desktop) で 89 examples / 0 failures (1 pending) で通ることを確認
- [ ] `scenario/test_with_mysql2.sh` のローカル実行確認
- [ ] CI (GitHub Actions) で従来通りグリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)