### PR TITLE
パス指定の ~ 展開と config-dir バリデーション追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/dump/
 
 # rspec failure tracking
 .rspec_status

--- a/lib/exwiw/adapter/sqlite3_adapter.rb
+++ b/lib/exwiw/adapter/sqlite3_adapter.rb
@@ -157,7 +157,7 @@ module Exwiw
         @connection ||=
           begin
             require 'sqlite3'
-            SQLite3::Database.new(@connection_config.database_name)
+            SQLite3::Database.new(File.expand_path(@connection_config.database_name))
           end
       end
     end

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -79,10 +79,6 @@ module Exwiw
           end
         end
 
-        if @config_dir.nil?
-          $stderr.puts "Config dir is required"
-        end
-
         if @database_password.nil? || @database_password.empty?
           $stderr.puts "environment variable 'DATABASE_PASSWORD' is required"
           exit 1
@@ -92,6 +88,21 @@ module Exwiw
       valid_adapters = ["mysql2", "postgresql", "sqlite3"]
       unless valid_adapters.include?(@database_adapter)
         $stderr.puts "Invalid adapter. Available options are: #{valid_adapters.join(', ')}"
+        exit 1
+      end
+
+      if @config_dir.nil?
+        $stderr.puts "Config dir is required"
+        exit 1
+      end
+
+      unless Dir.exist?(@config_dir)
+        $stderr.puts "Config dir does not exist: #{@config_dir}"
+        exit 1
+      end
+
+      if Dir.glob(File.join(@config_dir, "*.json")).empty?
+        $stderr.puts "Config dir contains no .json files: #{@config_dir}"
         exit 1
       end
 
@@ -130,10 +141,12 @@ module Exwiw
         opts.on("-p", "--port=PORT", "Target database port") { |v| @database_port = v }
         opts.on("-u", "--user=USERNAME", "Target database user") { |v| @database_user = v }
         opts.on("-o", "--output-dir=[DUMP_DIR_PATH]", "Output file path. default is dump/") do |v|
-          @output_dir = v.end_with?("/") ? v[0..-2] : v
+          v = v.end_with?("/") ? v[0..-2] : v
+          @output_dir = File.expand_path(v)
         end
         opts.on("-c", "--config-dir=CONFIG_DIR_PATH", "Config dir path.") do |v|
-          @config_dir = v.end_with?("/") ? v[0..-2] : v
+          v = v.end_with?("/") ? v[0..-2] : v
+          @config_dir = File.expand_path(v)
         end
         opts.on("-a", "--adapter=ADAPTER", "Database adapter") { |v| @database_adapter = v }
         opts.on("--database=DATABASE", "Target database name") { |v| @database_name = v }


### PR DESCRIPTION
## Summary
- `--config-dir` / `--output-dir`、および sqlite3 の `--database` パスを `File.expand_path` で展開し、`--option=~/path` 形式 (zshで `magic_equal_subst` 未設定時に `~` が展開されないケース) でも動くようにする
- `--config-dir` が未指定 / 存在しない / `*.json` を含まない場合に明示的にエラー終了するようにする

## Background
`bundle exec ./exe/exwiw --config-dir=~/path/to/config ...` を実行しても何も出力されない事象を踏んだのが発端でした。zshは `--option=~/...` 形式の `~` を展開しないため `~` が文字列のまま渡され、`Dir.glob` も展開しないので設定ファイルが0件読み込まれ、エラーも出ずに静かに終了していました。

## Test plan
- [x] `--config-dir=~/...` 形式で実行して期待通りSQLが生成されること
- [x] 存在しないディレクトリを指定すると `Config dir does not exist: ...` でexit 1
- [x] 空のディレクトリ (jsonなし) を指定すると `Config dir contains no .json files: ...` でexit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)