### PR TITLE
Fix incorrect left-side table in JOIN clause for chains with 3+ hops

### DIFF
--- a/lib/exwiw/adapter/mysql2_adapter.rb
+++ b/lib/exwiw/adapter/mysql2_adapter.rb
@@ -79,7 +79,7 @@ module Exwiw
         sql += " FROM #{query_ast.from_table_name}"
 
         query_ast.join_clauses.each do |join|
-          sql += " JOIN #{join.join_table_name} ON #{query_ast.from_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
+          sql += " JOIN #{join.join_table_name} ON #{join.base_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
 
           join.where_clauses.each do |where|
             compiled_where_condition = compile_where_condition(where, join.join_table_name)

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -79,7 +79,7 @@ module Exwiw
         sql += " FROM #{query_ast.from_table_name}"
 
         query_ast.join_clauses.each do |join|
-          sql += " JOIN #{join.join_table_name} ON #{query_ast.from_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
+          sql += " JOIN #{join.join_table_name} ON #{join.base_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
 
           join.where_clauses.each do |where|
             compiled_where_condition = compile_where_condition(where, join.join_table_name)

--- a/lib/exwiw/adapter/sqlite3_adapter.rb
+++ b/lib/exwiw/adapter/sqlite3_adapter.rb
@@ -79,7 +79,7 @@ module Exwiw
         sql += " FROM #{query_ast.from_table_name}"
 
         query_ast.join_clauses.each do |join|
-          sql += " JOIN #{join.join_table_name} ON #{query_ast.from_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
+          sql += " JOIN #{join.join_table_name} ON #{join.base_table_name}.#{join.foreign_key} = #{join.join_table_name}.#{join.primary_key}"
 
           join.where_clauses.each do |where|
             compiled_where_condition = compile_where_condition(where, join.join_table_name)

--- a/spec/adapter/mysql2_adapter_spec.rb
+++ b/spec/adapter/mysql2_adapter_spec.rb
@@ -81,6 +81,16 @@ module Exwiw
             )
           end
         end
+
+        context "select query with two joins" do
+          let(:sql) { adapter.compile_ast(build_transactions_two_join_ast) }
+
+          it "uses each join's base table on the left side of ON" do
+            expect(sql).to eq(
+              "SELECT transactions.id, transactions.type, transactions.amount, transactions.order_id, transactions.updated_at, transactions.created_at FROM transactions JOIN orders ON transactions.order_id = orders.id JOIN shops ON orders.shop_id = shops.id AND shops.id = 1"
+            )
+          end
+        end
       end
 
       describe "#execute" do

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -81,6 +81,16 @@ module Exwiw
             )
           end
         end
+
+        context "select query with two joins" do
+          let(:sql) { adapter.compile_ast(build_transactions_two_join_ast) }
+
+          it "uses each join's base table on the left side of ON" do
+            expect(sql).to eq(
+              "SELECT transactions.id, transactions.type, transactions.amount, transactions.order_id, transactions.updated_at, transactions.created_at FROM transactions JOIN orders ON transactions.order_id = orders.id JOIN shops ON orders.shop_id = shops.id AND shops.id = 1"
+            )
+          end
+        end
       end
 
       describe "#execute" do

--- a/spec/adapter/sqlite3_adapter_spec.rb
+++ b/spec/adapter/sqlite3_adapter_spec.rb
@@ -81,6 +81,16 @@ module Exwiw
             )
           end
         end
+
+        context "select query with two joins" do
+          let(:sql) { adapter.compile_ast(build_transactions_two_join_ast) }
+
+          it "uses each join's base table on the left side of ON" do
+            expect(sql).to eq(
+              "SELECT transactions.id, transactions.type, transactions.amount, transactions.order_id, transactions.updated_at, transactions.created_at FROM transactions JOIN orders ON transactions.order_id = orders.id JOIN shops ON orders.shop_id = shops.id AND shops.id = 1"
+            )
+          end
+        end
       end
 
       describe "#execute" do

--- a/spec/support/ast_factory.rb
+++ b/spec/support/ast_factory.rb
@@ -62,6 +62,39 @@ module AstFactory
     end
   end
 
+  def build_transactions_two_join_ast
+    transactions_table = transactions_table(adapter_name)
+
+    QueryAst::Select.new.tap do |ast|
+      ast.from(transactions_table.name)
+      ast.select(transactions_table.columns)
+      ast.join(
+        QueryAst::JoinClause.new(
+          base_table_name: "transactions",
+          foreign_key: "order_id",
+          join_table_name: "orders",
+          primary_key: "id",
+          where_clauses: [],
+        )
+      )
+      ast.join(
+        QueryAst::JoinClause.new(
+          base_table_name: "orders",
+          foreign_key: "shop_id",
+          join_table_name: "shops",
+          primary_key: "id",
+          where_clauses: [
+            QueryAst::WhereClause.new(
+              column_name: "id",
+              operator: :eq,
+              value: [1],
+            ),
+          ],
+        )
+      )
+    end
+  end
+
   def build_order_items_ast(order_items_filter_opt = nil, orders_filter_opt = nil)
     order_items_table = order_items_table(adapter_name)
 


### PR DESCRIPTION
## Summary

`Adapter#compile_ast` was always using `query_ast.from_table_name` as the left side of every `JOIN ... ON` clause. For 3+ hop join chains, the second and later JOINs ended up referencing a column on the wrong table, producing SQL like `JOIN C ON A.fk = C.id` instead of `JOIN C ON B.fk = C.id`. This caused `no such column` / `column does not exist` errors at execute time.

The `JoinClause` value object already carries `base_table_name` (the previous table in the chain), populated correctly by `QueryAstBuilder#build_join_clauses` via `path_tables.each_cons(2)`. The adapters just weren't using it.

## Reproduction

With a dump target `users` and a related table whose join path is 3 hops away (e.g. `reschedules → events → calendars → users`), the generated SQL was:

```sql
JOIN calendars ON reschedules.calendar_id = calendars.id  -- wrong: reschedules has no calendar_id
```

After this fix:

```sql
JOIN calendars ON events.calendar_id = calendars.id
```

For 1-hop chains the bug never manifested because `query_ast.from_table_name == join.base_table_name` happens to coincide.

## Changes

- `lib/exwiw/adapter/{sqlite3,mysql2,postgresql}_adapter.rb`: replace `query_ast.from_table_name` with `join.base_table_name` in `compile_ast`'s JOIN line
- `spec/support/ast_factory.rb`: add `build_transactions_two_join_ast` helper that builds a 2-hop AST where the second join's base table differs from the FROM table
- `spec/adapter/{sqlite3,mysql2,postgresql}_adapter_spec.rb`: add a `compile_ast` example for 2-hop joins

## Test plan

- [x] `bundle exec rspec` passes (92 examples, 0 failures, 1 pre-existing pending)
- [x] The originally failing CLI invocation now exits 0 and produces the corrected SQL