### PR TITLE
Add bulk_insert_chunk_size to TableConfig

### DIFF
--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -46,9 +46,11 @@ module Exwiw
         end
         @logger.debug("  Generate INSERT SQL...")
 
-        insert_sql = adapter.to_bulk_insert(results, table)
+        chunk_size = table.bulk_insert_chunk_size
+        chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
+        insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
 
-        @logger.info("  Generated INSERT SQL for #{record_num} records.")
+        @logger.info("  Generated INSERT SQL for #{record_num} records (#{chunks.size} statement(s)).")
         insert_idx = (idx + 1).to_s.rjust(3, '0')
         File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.sql"), 'w') do |file|
           file.puts(insert_sql)

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -9,6 +9,7 @@ module Exwiw
     attribute :filter, optional(String), skip_serializing_if_nil: true
     attribute :belongs_tos, array(BelongsTo)
     attribute :columns, array(TableColumn)
+    attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
 
     def self.from_symbol_keys(hash)
       from(JSON.parse(hash.to_json))
@@ -74,6 +75,7 @@ module Exwiw
         merged_table.primary_key = passed_table.primary_key
         merged_table.filter = filter
         merged_table.belongs_tos = passed_table.belongs_tos
+        merged_table.bulk_insert_chunk_size = passed_table.bulk_insert_chunk_size
 
         receiver_column_by_name = columns.each_with_object({}) { |column, hash| hash[column.name] = column }
 

--- a/scenario/import_with_sqlite3.rb
+++ b/scenario/import_with_sqlite3.rb
@@ -6,11 +6,11 @@ connection = SQLite3::Database.new(new_db_path)
 Dir["tmp/sqlite3/delete-*.sql"].each do |file|
   puts "Run #{file}"
   sql = File.read(file)
-  connection.execute(sql)
+  connection.execute_batch(sql)
 end
 
 Dir["tmp/sqlite3/insert-*.sql"].each do |file|
   puts "Run #{file}"
   sql = File.read(file)
-  connection.execute(sql)
+  connection.execute_batch(sql)
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'fileutils'
+require 'json'
 
 module Exwiw
   RSpec.describe Runner do
@@ -27,6 +29,59 @@ module Exwiw
 
     it 'writes bulk insert SQL to the output file' do
       expect { runner.run }.not_to raise_error
+    end
+
+    describe 'with bulk_insert_chunk_size' do
+      let(:config_dir) { 'tmp/runner_spec_config' }
+      let(:output_dir) { 'tmp/runner_spec_output' }
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2', '3', '4', '5']) }
+
+      before do
+        FileUtils.rm_rf(config_dir)
+        FileUtils.rm_rf(output_dir)
+        FileUtils.mkdir_p(config_dir)
+
+        shops_config = JSON.parse(File.read('scenario/sqlite3-schema/shops.json'))
+        shops_config['bulk_insert_chunk_size'] = 2
+        File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops_config))
+      end
+
+      it 'splits INSERT statements into chunks within a single file' do
+        runner.run
+
+        sql_file = Dir[File.join(output_dir, 'insert-*-shops.sql')].first
+        expect(sql_file).not_to be_nil
+
+        sql = File.read(sql_file)
+        insert_statements = sql.scan(/INSERT INTO shops/)
+        expect(insert_statements.size).to eq(3)
+
+        expect(sql).to match(/INSERT INTO shops .+ VALUES\n\([^)]+\),\n\([^)]+\);/m)
+      end
+    end
+
+    describe 'without bulk_insert_chunk_size' do
+      let(:config_dir) { 'tmp/runner_spec_config_nochunk' }
+      let(:output_dir) { 'tmp/runner_spec_output_nochunk' }
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2', '3', '4', '5']) }
+
+      before do
+        FileUtils.rm_rf(config_dir)
+        FileUtils.rm_rf(output_dir)
+        FileUtils.mkdir_p(config_dir)
+
+        FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
+      end
+
+      it 'emits a single INSERT statement per table' do
+        runner.run
+
+        sql_file = Dir[File.join(output_dir, 'insert-*-shops.sql')].first
+        expect(sql_file).not_to be_nil
+
+        sql = File.read(sql_file)
+        expect(sql.scan(/INSERT INTO shops/).size).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

`TableConfig` に optional な `bulk_insert_chunk_size` (Integer) を追加し、設定したテーブルでは bulk INSERT を指定行数ごとに複数文へ分割して、同じ `.sql` ファイル内に並べて出力できるようにします。未設定なら従来どおり 1 INSERT 文 / 1 ファイルで挙動は変わりません。

これにより MySQL の `max_allowed_packet` や SQLite の `SQLITE_MAX_SQL_LENGTH` を超えるサイズの bulk insert を回避できます。

## 変更内容

- `lib/exwiw/table_config.rb`: optional Integer 属性を1つ追加 (`merge` でも伝播)
- `lib/exwiw/runner.rb`: chunk_size が設定されているとき `each_slice` で分割し、`to_bulk_insert` を chunk ごとに呼んで結果を改行連結
- `scenario/import_with_sqlite3.rb`: 複数文の INSERT を扱うため `execute` → `execute_batch`
- `spec/runner_spec.rb`: chunk 有/無の振る舞いテストを追加

adapter API (`to_bulk_insert(results, table)`) は変更なし。

## 使い方

```json
{
  \"name\": \"google_calendar_events\",
  \"primary_key\": \"id\",
  \"bulk_insert_chunk_size\": 1000,
  ...
}
```

このテーブルだけ 1000 行ごとに INSERT 文が区切られます。出力ファイル名・ファイル数は変わりません。

出力イメージ (chunk_size=2, 5 行のとき同じ .sql 内に 3 文):

\`\`\`sql
INSERT INTO events (...) VALUES
(...),
(...);
INSERT INTO events (...) VALUES
(...),
(...);
INSERT INTO events (...) VALUES
(...);
\`\`\`

mysql / psql / sqlite3 いずれもセミコロンで区切られた複文をそのまま流せるため、import 手順は従来と同じです。

## Test plan

- [x] `bundle exec rspec` 全体パス (chunk有/無のテストを `spec/runner_spec.rb` に追加)
- [x] `scenario/test_with_sqlite3.sh` パス
- [x] `scenario/test_with_mysql2.sh` パス
- [x] `scenario/test_with_postgresql.sh` パス
- [x] `products` に `chunk_size: 2` を一時設定 → 3行が 2文 (2+1) に分割されることを実機確認

## 付録: パケットサイズ上限と必要 chunk_size の目安

### DB 側の上限

| DB | 上限 | 備考 |
|---|---|---|
| MySQL | `max_allowed_packet` (デフォルト 4MB〜64MB) | 超えると \`Got a packet bigger than 'max_allowed_packet' bytes\` |
| PostgreSQL | 1メッセージ 1GB | 実用上は \`work_mem\` 等で先に詰まる |
| SQLite | \`SQLITE_MAX_SQL_LENGTH\` (デフォルト 1MB、ビルド時最大 1GB) | 古い版では VALUES の行数も最大 500 |

### 1行あたりサイズ別 4MB 到達行数

| 1行 | 例 | 4MB に収まる行数 |
|---|---|---|
| 〜100B | id+FK+timestamp 程度の細いテーブル (\`sessions\` 系) | 約 40,000 |
| 〜300B | 普通のカラム数、短い文字列中心 (\`users\` 系) | 約 14,000 |
| 〜500B | テキストカラム少しあり | 約 8,000 |
| 〜1KB | URL や短い JSON を含む | 約 4,000 |
| 〜1.2KB | JSON カラム入りのリッチなテーブル | 約 3,400 |
| 〜5KB | 本文 / 長い TEXT / 大きめ JSON | 約 800 |
| 〜10KB | LONGTEXT / base64 画像など | 約 400 |

### 推奨 chunk_size

- MySQL のデフォルト \`max_allowed_packet=64MB\` (5.7+) なら、上記 16 倍まで 1 文で送れる (1.2KB/行で約 5万行)
- ワーストケースは \`max_allowed_packet=4MB\` を引きずる古い環境
- 安全寄りに分割するなら **「1 chunk = 1,000 行 or 2MB のどちらか早い方」** あたりが無難

🤖 Generated with [Claude Code](https://claude.com/claude-code)