### PR TITLE
Prep Adapter contract for non-SQL backends

### DIFF
--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -9,6 +9,24 @@ module Exwiw
         @connection_config = connection_config
         @logger = logger
       end
+
+      # @params [Exwiw::TableConfig] table
+      # @params [Exwiw::DumpTarget] dump_target
+      # @params [Hash{String => Exwiw::TableConfig}] table_by_name
+      # @return [Object] adapter-specific query object (e.g. Exwiw::QueryAst::Select for SQL)
+      def build_query(table, dump_target, table_by_name)
+        raise NotImplementedError
+      end
+
+      # File extension used for dump output (e.g. 'sql' for SQL, 'jsonl' for MongoDB).
+      def output_extension
+        'sql'
+      end
+
+      # Whether this adapter emits delete-NNN-*.sql files.
+      def supports_bulk_delete?
+        true
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mysql2_adapter.rb
+++ b/lib/exwiw/adapter/mysql2_adapter.rb
@@ -3,6 +3,10 @@
 module Exwiw
   module Adapter
     class Mysql2Adapter < Base
+      def build_query(table, dump_target, table_by_name)
+        Exwiw::QueryAstBuilder.run(table.name, table_by_name, dump_target, @logger)
+      end
+
       def execute(query_ast)
         sql = compile_ast(query_ast)
 

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -3,6 +3,10 @@
 module Exwiw
   module Adapter
     class PostgresqlAdapter < Base
+      def build_query(table, dump_target, table_by_name)
+        Exwiw::QueryAstBuilder.run(table.name, table_by_name, dump_target, @logger)
+      end
+
       def execute(query_ast)
         sql = compile_ast(query_ast)
 

--- a/lib/exwiw/adapter/sqlite3_adapter.rb
+++ b/lib/exwiw/adapter/sqlite3_adapter.rb
@@ -3,6 +3,10 @@
 module Exwiw
   module Adapter
     class Sqlite3Adapter < Base
+      def build_query(table, dump_target, table_by_name)
+        Exwiw::QueryAstBuilder.run(table.name, table_by_name, dump_target, @logger)
+      end
+
       def execute(query_ast)
         sql = compile_ast(query_ast)
 

--- a/lib/exwiw/query_ast_builder.rb
+++ b/lib/exwiw/query_ast_builder.rb
@@ -77,7 +77,7 @@ module Exwiw
 
       if table.name == dump_target.table_name
         clauses.push Exwiw::QueryAst::WhereClause.new(
-          column_name: 'id',
+          column_name: table.primary_key,
           operator: :eq,
           value: dump_target.ids
         )

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -36,7 +36,7 @@ module Exwiw
         @logger.info("Processing table '#{table_name}'... (#{idx + 1}/#{total_size})")
         table = table_by_name.fetch(table_name)
 
-        query_ast = QueryAstBuilder.run(table.name, table_by_name, @dump_target, @logger)
+        query_ast = adapter.build_query(table, @dump_target, table_by_name)
         results = adapter.execute(query_ast)
         record_num = results.size
 
@@ -44,28 +44,30 @@ module Exwiw
           @logger.info("  No records matched. skip this table.")
           next
         end
-        @logger.debug("  Generate INSERT SQL...")
+        @logger.debug("  Generate INSERT statement...")
 
         chunk_size = table.bulk_insert_chunk_size
         chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
         insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
 
-        @logger.info("  Generated INSERT SQL for #{record_num} records (#{chunks.size} statement(s)).")
+        @logger.info("  Generated INSERT statement for #{record_num} records (#{chunks.size} statement(s)).")
         insert_idx = (idx + 1).to_s.rjust(3, '0')
-        File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.sql"), 'w') do |file|
+        File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
           file.puts(insert_sql)
         end
 
-        @logger.debug("  Generate DELETE SQL...")
-        delete_sql = adapter.to_bulk_delete(query_ast, table)
-        if @logger.debug?
-          @logger.debug("  Generated DELETE SQL:\n#{delete_sql}")
-        else
-          @logger.info("  Generated DELETE SQL.")
-        end
-        delete_idx = (total_size - idx).to_s.rjust(3, '0')
-        File.open(File.join(@output_dir, "delete-#{delete_idx}-#{table_name}.sql"), 'w') do |file|
-          file.puts(delete_sql)
+        if adapter.supports_bulk_delete?
+          @logger.debug("  Generate DELETE statement...")
+          delete_sql = adapter.to_bulk_delete(query_ast, table)
+          if @logger.debug?
+            @logger.debug("  Generated DELETE statement:\n#{delete_sql}")
+          else
+            @logger.info("  Generated DELETE statement.")
+          end
+          delete_idx = (total_size - idx).to_s.rjust(3, '0')
+          File.open(File.join(@output_dir, "delete-#{delete_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+            file.puts(delete_sql)
+          end
         end
       end
     end


### PR DESCRIPTION
## Background

非SQLバックエンド(MongoDB)アダプタを追加したいというモチベーションがあり、その下準備となる契約変更を先に切り出した PR です。詳細プランは fork 側の issue を参照ください:

- ykpythemind/exwiw#5 — MongoDB アダプタ追加 実装プラン (B'案: per-adapter strategy)

本 PR 自体は **SQL アダプタの挙動を変えずに**、Adapter 層に追加フックを差し込むだけの変更です。MongoDB 本体の追加は別 PR を予定。

## Summary

- `Adapter#build_query(table, dump_target, table_by_name)` を新設し、query 構築をアダプタ側に委譲。SQL アダプタは従来通り `QueryAstBuilder.run(...)` をラップして `QueryAst::Select` を返すだけ。
- `Adapter#output_extension`(デフォルト `'sql'`)と `Adapter#supports_bulk_delete?`(デフォルト `true`)を追加。runner はこれらを参照して出力ファイル拡張子を切り替え、DELETE 出力を gate する。
- `QueryAstBuilder` で dump_target.ids を WHERE に展開する箇所、`column_name: 'id'` ハードコードを `table.primary_key` に修正(副次的なバグ修正)。
- ログ文言の `INSERT SQL` / `DELETE SQL` → `INSERT statement` / `DELETE statement` に微修正(非SQLアダプタでも違和感がないように)。

SQL アダプタ側の `compile_ast` / `to_bulk_insert` / `to_bulk_delete`(subquery 含む)は **一切無変更** です。

## Test plan

- [x] CI green (fork 側で確認済み)
- [ ] 既存の adapter / runner / scenario specs が引き続き通ること