### PR TITLE
MongoDB: insert-000-schema.js を from-clean シナリオで end-to-end 検証

### DIFF
--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -136,6 +136,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install mongosh
+        # The mongo:7 service container has mongosh inside it, but the
+        # ubuntu-latest host does not. The from-clean scenario shells out to
+        # mongosh from the host to apply insert-000-schema.js, so install it
+        # via MongoDB's apt repo.
+        #
+        # The repo path is pinned to `jammy` rather than `$(lsb_release -cs)`
+        # because MongoDB's 7.0 apt index does not always carry an entry for
+        # the latest Ubuntu codename used by ubuntu-latest. mongosh itself is
+        # codename-agnostic, so the jammy build runs fine on newer hosts.
+        run: |
+          curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor
+          echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-mongosh
+          mongosh --version
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -144,3 +161,6 @@ jobs:
 
       - name: Run exwiw
         run: scenario/test_with_mongodb.sh
+
+      - name: Run exwiw (from clean target DB)
+        run: scenario/test_with_mongodb_from_clean.sh

--- a/docs/plans/2026-05-16-mongodb-from-clean-scenario.md
+++ b/docs/plans/2026-05-16-mongodb-from-clean-scenario.md
@@ -1,0 +1,76 @@
+# Plan: MongoDB の `insert-000-schema.js` を scenario で end-to-end 検証する
+
+## Context
+
+`lib/exwiw/adapter/mongodb_adapter.rb#dump_schema` は `insert-000-schema.js` に
+`createCollection` / `createIndex` を書き出す実装を既に持っているが、scenario 側で
+これを apply するパスが無く、CI でも検証できていなかった。具体的なギャップ:
+
+1. `scenario/setup_with_mongodb.rb` は seed を `insert_many` で流すだけで、index を一切作っていない
+2. その結果 `tmp/mongodb/insert-000-schema.js` は `createCollection` 行のみで `createIndex` が 0 行
+3. `scenario/import_with_mongodb.rb` は `insert-*.jsonl` だけを glob して処理しており、`insert-000-schema.js` を一切実行しない
+
+sqlite3 / mysql2 / postgresql で導入済みの「from clean DB から立ち上げる」流れと
+MongoDB の `insert-000-schema.js` が連動していない状態だった (issue #16)。
+
+## ゴール
+
+- 空の target DB に対して `mongosh insert-000-schema.js` → `insert-*.jsonl` の順で適用する scenario を CI に乗せる
+- source DB に代表的な index を作り、`dump_schema` が `createIndex` 行を実際に吐く状態を作る
+- 生成された createIndex 行が mongosh で実際に通ること、target 側で index が round-trip することを検証
+- 既存の snapshot test (`spec/insert_output_snapshot_spec.rb`) でも createIndex 行を固定化
+
+## 変更内容
+
+### scenario 層
+| パス | 変更 |
+|---|---|
+| `scenario/setup_with_mongodb.rb` | seed 流し込みの後に 3 種類の代表的 index を作る (unique `shops.name` / plain `users.email` / 複合 `orders.shop_id+user_id`) |
+| `scenario/import_with_mongodb.rb` | `--no-drop` と `--input-dir DIR` フラグを追加。from-clean は drop すると schema.js が作った index ごと消えてしまうため |
+| `scenario/verify_with_mongodb.rb` | `--with-indexes` で target collection の index を assert (default scenario では import 時に drop されるのでスキップ) |
+| `scenario/test_with_mongodb_from_clean.sh` (新規) | `mongosh dropDatabase` → exwiw 実行 → `mongosh insert-000-schema.js` → `import --no-drop --input-dir tmp/mongodb-clean` → `verify --with-indexes` |
+| `.github/workflows/scenario.yml` | with_mongodb job に `mongodb-mongosh` install ステップと `test_with_mongodb_from_clean.sh` 実行ステップを追加。apt repo の codename は `jammy` 固定 (ubuntu-latest が noble に上がる前提) |
+
+### snapshot test 層
+| パス | 変更 |
+|---|---|
+| `spec/support/bootstrap_databases.rb` | scenario と同じ 3 index を bootstrap で作る |
+| `spec/insert_output_snapshots/mongodb/insert-000-schema.js` | 3 つの `db.getCollection(...).createIndex(...)` 行が追加される形で再生成 |
+
+## 設計上の判断
+
+- **unique index は `users.email` ではなく `shops.name` に貼る**: seed の `users.email`
+  は `user1@example.com` が 5 shop に重複するので unique にできない。`shops.name`
+  ("Shop 1".."Shop 5") は seed 上一意なので unique 可。
+- **既存 scenario への副作用を最小化**: `import_with_mongodb.rb` のデフォルト挙動は変えず
+  `--no-drop` フラグで opt-in。既存 `test_with_mongodb.sh` は無修正で動く。
+- **verify を 2 用途で兼用**: `--with-indexes` 切り替えで from-clean のみ index を見る。
+  既存 scenario は drop→insert で index が無くなるため index 検証はスキップ。
+- **CI への mongosh install**: `mongo:7` service container には mongosh があるが、
+  ubuntu-latest 上の `mongosh` コマンドは別。MongoDB の apt repo (`mongodb-mongosh`
+  パッケージ) を入れる。codename は `jammy` 固定 (MongoDB 7.0 repo が noble を
+  carry していない時期があるため)。
+- **snapshot fixture を indexes 入りに更新**: bootstrap_databases.rb と
+  setup_with_mongodb.rb で同じ index を作るので、snapshot test と scenario test の
+  期待値が分岐しない。
+
+## Verification
+
+- `bash scenario/test_with_mongodb.sh` 既存 scenario 維持を確認 ✓
+- `bash scenario/test_with_mongodb_from_clean.sh` 新規 scenario 通過を確認
+  (indexes round-trip OK) ✓
+- `bundle exec rspec` 全 153 examples / 0 failures ✓
+- `tmp/mongodb-clean/insert-000-schema.js` を目視で確認:
+  ```js
+  db.getCollection("shops").createIndex({"name":1}, {"unique":true,"name":"idx_shops_name"});
+  db.getCollection("users").createIndex({"email":1}, {"name":"idx_users_email"});
+  db.getCollection("orders").createIndex({"shop_id":1,"user_id":1}, {"name":"idx_orders_shop_user"});
+  ```
+
+## 留意点
+
+- `import_with_mongodb.rb` のフラグ解析は手書きの ARGV パース。引数が増えるなら
+  OptionParser 化を検討する余地あり (現状は 2 フラグなので過剰)。
+- ubuntu-latest が将来 codename を変えても apt repo の `jammy` 指定は壊れない想定だが、
+  MongoDB 8.x へ移行する際は repo URL の `7.0` も更新が必要。
+- 既存 issue #16 のスコープは MongoDB のみ。SQL 系の from_clean は別 PR で導入済み。

--- a/scenario/import_with_mongodb.rb
+++ b/scenario/import_with_mongodb.rb
@@ -2,18 +2,37 @@ require 'json'
 
 require_relative './mongodb_client'
 
-database_name = ARGV.first
+args = ARGV.dup
+# `--no-drop` is used by the from-clean scenario, where insert-000-schema.js
+# has already created collections and indexes — dropping would wipe them.
+no_drop = args.delete("--no-drop")
+# `--input-dir DIR` lets the from-clean scenario point at its own output dir
+# without colliding with the default scenario's tmp/mongodb artifacts.
+input_dir_idx = args.index("--input-dir")
+input_dir =
+  if input_dir_idx
+    args.delete_at(input_dir_idx)
+    args.delete_at(input_dir_idx)
+  else
+    "tmp/mongodb"
+  end
+
+database_name = args.first
 raise "database name required" if database_name.nil? || database_name.empty?
 
 client = MongodbScenario.client(database_name)
 
-# MongoDB adapter does not emit delete-*.jsonl, so drop each target collection first.
-files = Dir.glob("tmp/mongodb/insert-*.jsonl").sort
+# MongoDB adapter does not emit delete-*.jsonl, so the default scenario drops
+# each target collection before inserting. The from-clean scenario opts out
+# via --no-drop because the empty target was just set up by insert-000-schema.js.
+files = Dir.glob(File.join(input_dir, "insert-*.jsonl")).sort
 
-files.each do |path|
-  collection_name = File.basename(path, ".jsonl").sub(/\Ainsert-\d+-/, "")
-  puts "Drop #{collection_name}"
-  client[collection_name].drop
+unless no_drop
+  files.each do |path|
+    collection_name = File.basename(path, ".jsonl").sub(/\Ainsert-\d+-/, "")
+    puts "Drop #{collection_name}"
+    client[collection_name].drop
+  end
 end
 
 files.each do |path|

--- a/scenario/setup_with_mongodb.rb
+++ b/scenario/setup_with_mongodb.rb
@@ -14,4 +14,13 @@ Dir.glob("seed/mongodb/*.jsonl").each do |path|
   client[collection_name].insert_many(docs) unless docs.empty?
 end
 
+# Create representative indexes so dump_schema has something to emit and the
+# from-clean scenario can verify createIndex statements actually round-trip
+# through mongosh. Covers: a unique index, a plain index, and a compound index.
+# (shops.name is unique in the seed; users.email is *not* — same email
+# repeats across shops — so the unique flag lives on shops.)
+client["shops"].indexes.create_one({ "name" => 1 }, name: "idx_shops_name", unique: true)
+client["users"].indexes.create_one({ "email" => 1 }, name: "idx_users_email")
+client["orders"].indexes.create_one({ "shop_id" => 1, "user_id" => 1 }, name: "idx_orders_shop_user")
+
 client.close

--- a/scenario/test_with_mongodb_from_clean.sh
+++ b/scenario/test_with_mongodb_from_clean.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Variant of test_with_mongodb.sh that exercises the "fresh target DB" path.
+# The TO database starts empty (no collections, no indexes), so the run must
+# succeed purely on the strength of insert-000-schema.js creating each
+# collection and its indexes before the insert-*.jsonl payload lands.
+#
+# Unlike test_with_mongodb.sh, import_with_mongodb.rb is invoked with
+# --no-drop so the collections that insert-000-schema.js just created (and
+# the indexes attached to them) survive into the verify step.
+
+set -e
+
+export FROM_DATABASE_NAME="exwiw_scenario_prod_db"
+export TO_DATABASE_NAME="exwiw_scenario_dev_clean_db"
+export MONGO_HOST="${MONGO_HOST:-127.0.0.1}"
+export MONGO_PORT="${MONGO_PORT:-27017}"
+
+mkdir -p tmp/mongodb-clean
+rm -f tmp/mongodb-clean/*.jsonl tmp/mongodb-clean/*.js
+
+# Wipe the TO database so the from-clean assumption (no collections, no
+# indexes) actually holds. mongosh with --eval lets us do this without a
+# helper script.
+mongosh --quiet "mongodb://${MONGO_HOST}:${MONGO_PORT}/${TO_DATABASE_NAME}" \
+  --eval 'db.dropDatabase()' > /dev/null
+
+# Setup source db from seed (also creates representative indexes that
+# dump_schema should pick up).
+bundle exec ruby scenario/setup_with_mongodb.rb "${FROM_DATABASE_NAME}"
+
+# Run exwiw — output to a dedicated dir so we don't collide with the default
+# scenario's artifacts.
+bundle exec exe/exwiw \
+  --adapter=mongodb \
+  --host="${MONGO_HOST}" \
+  --port="${MONGO_PORT}" \
+  --database="${FROM_DATABASE_NAME}" \
+  --config-dir=scenario/mongodb-schema \
+  --target-table=shops \
+  --ids=1 \
+  --output-dir=tmp/mongodb-clean \
+  --log-level=debug
+
+# Apply insert-000-schema.js against the empty TO database. This must create
+# every collection and index referenced by the subsequent insert-*.jsonl.
+SCHEMA_FILE="tmp/mongodb-clean/insert-000-schema.js"
+if [ ! -f "$SCHEMA_FILE" ]; then
+  echo "✗ ${SCHEMA_FILE} not generated"
+  exit 1
+fi
+echo "Run ${SCHEMA_FILE}"
+mongosh --quiet "mongodb://${MONGO_HOST}:${MONGO_PORT}/${TO_DATABASE_NAME}" "$SCHEMA_FILE"
+
+# Import the jsonl payload into the just-created collections. --no-drop keeps
+# the collections (and the indexes the schema file just made) intact.
+bundle exec ruby scenario/import_with_mongodb.rb --no-drop --input-dir tmp/mongodb-clean "${TO_DATABASE_NAME}"
+
+# Verify scoped dump landed correctly AND that the indexes round-tripped.
+echo "Verifying import to clean DB..."
+if bundle exec ruby scenario/verify_with_mongodb.rb "${TO_DATABASE_NAME}" --with-indexes; then
+  echo "✓ MongoDB from-clean scenario passed"
+else
+  echo "✗ MongoDB from-clean scenario verification failed"
+  exit 1
+fi

--- a/scenario/verify_with_mongodb.rb
+++ b/scenario/verify_with_mongodb.rb
@@ -3,6 +3,12 @@ require_relative './mongodb_client'
 database_name = ARGV.shift
 raise "database name required" if database_name.nil? || database_name.empty?
 
+# `--with-indexes` opts the from-clean scenario into checking that
+# insert-000-schema.js actually round-tripped the indexes seeded in
+# setup_with_mongodb.rb. The default scenario skips this because its import
+# step drops collections (and their indexes) before inserting jsonl.
+verify_indexes = ARGV.include?("--with-indexes")
+
 client = MongodbScenario.client(database_name)
 
 expected = {
@@ -51,6 +57,33 @@ if embedded_titles == expected_titles
 else
   puts "NG  users._id=1 embedded posts titles unexpected: #{embedded_titles.inspect}"
   failed = true
+end
+
+if verify_indexes
+  expected_indexes = {
+    "shops" => { "idx_shops_name" => { "key" => { "name" => 1 }, "unique" => true } },
+    "users" => { "idx_users_email" => { "key" => { "email" => 1 } } },
+    "orders" => { "idx_orders_shop_user" => { "key" => { "shop_id" => 1, "user_id" => 1 } } },
+  }
+
+  expected_indexes.each do |collection, indexes_by_name|
+    actual = client[collection].indexes.to_a.each_with_object({}) { |idx, h| h[idx["name"]] = idx }
+    indexes_by_name.each do |name, expected|
+      idx = actual[name]
+      if idx.nil?
+        puts "NG  #{collection} missing index #{name}"
+        failed = true
+        next
+      end
+      mismatches = expected.reject { |k, v| idx[k] == v }
+      if mismatches.empty?
+        puts "OK  #{collection} has index #{name}: #{expected.inspect}"
+      else
+        puts "NG  #{collection} index #{name} mismatch: expected #{expected.inspect}, got #{idx.slice(*expected.keys).inspect}"
+        failed = true
+      end
+    end
+  end
 end
 
 client.close

--- a/spec/insert_output_snapshots/mongodb/insert-000-schema.js
+++ b/spec/insert_output_snapshots/mongodb/insert-000-schema.js
@@ -8,3 +8,6 @@ try { db.createCollection("orders"); } catch (e) { if (e.code !== 48) throw e; }
 try { db.createCollection("order_items"); } catch (e) { if (e.code !== 48) throw e; }
 try { db.createCollection("transactions"); } catch (e) { if (e.code !== 48) throw e; }
 
+db.getCollection("shops").createIndex({"name":1}, {"unique":true,"name":"idx_shops_name"});
+db.getCollection("users").createIndex({"email":1}, {"name":"idx_users_email"});
+db.getCollection("orders").createIndex({"shop_id":1,"user_id":1}, {"name":"idx_orders_shop_user"});

--- a/spec/support/bootstrap_databases.rb
+++ b/spec/support/bootstrap_databases.rb
@@ -84,6 +84,12 @@ module BootstrapDatabases
       client[collection_name].insert_many(docs) unless docs.empty?
     end
 
+    # Mirror scenario/setup_with_mongodb.rb so the insert-000-schema.js
+    # snapshot exercises createIndex emission (unique / plain / compound).
+    client["shops"].indexes.create_one({ "name" => 1 }, name: "idx_shops_name", unique: true)
+    client["users"].indexes.create_one({ "email" => 1 }, name: "idx_users_email")
+    client["orders"].indexes.create_one({ "shop_id" => 1, "user_id" => 1 }, name: "idx_orders_shop_user")
+
     client.close
   end
 end


### PR DESCRIPTION
## Summary
- `scenario/setup_with_mongodb.rb` に代表的な index (unique / plain / compound) を 3 種追加し、`dump_schema` が `createIndex` 行を実際に吐く状態にする
- 新規 `scenario/test_with_mongodb_from_clean.sh` で空の target DB に `mongosh insert-000-schema.js` → `insert-*.jsonl` を流し、target 側の index round-trip を検証
- `import_with_mongodb.rb` に `--no-drop` / `--input-dir` を追加し、`verify_with_mongodb.rb` に `--with-indexes` を追加
- CI (with_mongodb job) に `mongodb-mongosh` の install と from-clean 実行ステップを追加
- snapshot test fixture (`spec/insert_output_snapshots/mongodb/insert-000-schema.js`) も createIndex 行を含むように更新

Closes #16

## Test plan
- [x] `bash scenario/test_with_mongodb.sh` 既存シナリオ通過
- [x] `bash scenario/test_with_mongodb_from_clean.sh` 新規シナリオ通過 (indexes round-trip 確認)
- [x] `bundle exec rspec` 全 153 examples / 0 failures
- [ ] CI (with_mongodb job) で from-clean step が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)