### PR TITLE
feat(postgresql): COPY FROM stdin 出力と全テーブルダンプモードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ exwiw \
   --log-level=info
 ```
 
+When `--target-table` and `--ids` are omitted, exwiw dumps all tables defined in `--config-dir`:
+
+```bash
+# dump all tables
+exwiw \
+  --adapter=postgresql \
+  --host=localhost \
+  --port=5432 \
+  --user=reader \
+  --database=app_production \
+  --config-dir=exwiw \
+  --output-dir=dump
+```
+
 This command will generate sql files in the `dump` directory.
 
 - `dump/insert-000-schema.sql` — idempotent `CREATE TABLE IF NOT EXISTS ...` for every table in scope. Apply this first to provision an empty database.
@@ -119,6 +133,32 @@ This is an example of the one table schema:
 ```
 
 `--config-dir` will use all json files in the specified directory.
+
+### Output format
+
+By default, exwiw generates `INSERT` statements. For PostgreSQL, you can use `--output-format=copy` to generate `COPY FROM stdin` format instead, which is significantly faster for bulk loading:
+
+```bash
+exwiw \
+  --adapter=postgresql \
+  --host=localhost \
+  --port=5432 \
+  --user=reader \
+  --database=app_production \
+  --config-dir=exwiw \
+  --target-table=shops \
+  --ids=1 \
+  --output-dir=dump \
+  --output-format=copy
+```
+
+The generated file uses tab-separated values with PostgreSQL's text-format escaping (`\N` for NULL, `\\` for backslash, etc.). Import with `psql`:
+
+```bash
+psql -d app_dev -f dump/insert-001-shops.sql
+```
+
+`--output-format=copy` is only supported with the `postgresql` adapter.
 
 ### Bulk insert chunk size
 

--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -70,6 +70,10 @@ module Exwiw
       def post_insert_sql(_table)
         nil
       end
+
+      def to_copy_from_stdin(_results, _table)
+        raise NotImplementedError, "COPY format is not supported by #{self.class.name}"
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -221,10 +221,10 @@ module Exwiw
           "\\N"
         when String
           value
-            .gsub("\\", "\\\\")
-            .gsub("\t", "\\t")
-            .gsub("\n", "\\n")
-            .gsub("\r", "\\r")
+            .gsub('\\') { '\\\\' }
+            .gsub("\t", '\t')
+            .gsub("\n", '\n')
+            .gsub("\r", '\r')
         else
           value.to_s
         end

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -74,6 +74,16 @@ module Exwiw
         "INSERT INTO #{table_name} (#{column_names}) VALUES\n#{values};"
       end
 
+      def to_copy_from_stdin(results, table)
+        column_names = table.columns.map(&:name).join(', ')
+        lines = ["COPY #{table.name} (#{column_names}) FROM stdin;"]
+        results.each do |row|
+          lines << row.map { |v| escape_copy_value(v) }.join("\t")
+        end
+        lines << '\\.'
+        lines.join("\n")
+      end
+
       # Transcribe the FROM-side sequence cursor backing `table.primary_key`
       # onto the import target. Without this, importing into a clean DB leaves
       # the sequence at 1 while the inserted rows occupy higher IDs, so the
@@ -202,6 +212,21 @@ module Exwiw
           "'#{qv}'"
         else
           value
+        end
+      end
+
+      private def escape_copy_value(value)
+        case value
+        when nil
+          "\\N"
+        when String
+          value
+            .gsub("\\", "\\\\")
+            .gsub("\t", "\\t")
+            .gsub("\n", "\\n")
+            .gsub("\r", "\\r")
+        else
+          value.to_s
         end
       end
 

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -28,6 +28,7 @@ module Exwiw
       @database_name = nil
       @target_table_name = nil
       @ids = []
+      @output_format = 'insert'
       @log_level = :info
 
       parser.parse!(@argv)
@@ -60,6 +61,7 @@ module Exwiw
           output_dir: @output_dir,
           config_dir: @config_dir,
           dump_target: dump_target,
+          output_format: @output_format,
           logger: logger,
         ).run
       end
@@ -92,6 +94,17 @@ module Exwiw
         exit 1
       end
 
+      valid_output_formats = ["insert", "copy"]
+      unless valid_output_formats.include?(@output_format)
+        $stderr.puts "Invalid output format '#{@output_format}'. Available options are: #{valid_output_formats.join(', ')}"
+        exit 1
+      end
+
+      if @output_format == "copy" && @database_adapter != "postgresql"
+        $stderr.puts "--output-format=copy is only supported with the postgresql adapter"
+        exit 1
+      end
+
       if @config_dir.nil?
         $stderr.puts "Config dir is required"
         exit 1
@@ -107,13 +120,13 @@ module Exwiw
         exit 1
       end
 
-      if @target_table_name.nil? || @target_table_name.empty?
-        $stderr.puts "Target table is required"
+      if @target_table_name && @ids.empty?
+        $stderr.puts "--ids is required when --target-table is specified"
         exit 1
       end
 
-      if @ids.empty?
-        $stderr.puts "At least one ID is required"
+      if !@target_table_name && @ids.any?
+        $stderr.puts "--target-table is required when --ids is specified"
         exit 1
       end
     end
@@ -151,8 +164,9 @@ module Exwiw
         end
         opts.on("-a", "--adapter=ADAPTER", "Database adapter") { |v| @database_adapter = v }
         opts.on("--database=DATABASE", "Target database name") { |v| @database_name = v }
-        opts.on("--target-table=TABLE", "Target table for extraction") { |v| @target_table_name = v }
-        opts.on("--ids=IDS", "Comma-separated list of identifiers") { |v| @ids = v.split(',') }
+        opts.on("--target-table=[TABLE]", "Target table for extraction. If omitted, dump all tables.") { |v| @target_table_name = v }
+        opts.on("--ids=[IDS]", "Comma-separated list of identifiers. Required when --target-table is given.") { |v| @ids = v.split(',') }
+        opts.on("--output-format=[FORMAT]", "Output format: insert (default) or copy (PostgreSQL only)") { |v| @output_format = v }
         opts.on("--log-level=LEVEL", "Log level (debug, info). default is info") { |v| @log_level = v.to_sym }
 
         opts.on("--help", "Print this help") do

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -9,12 +9,14 @@ module Exwiw
       output_dir:,
       config_dir:,
       dump_target:,
-      logger:
+      logger:,
+      output_format: 'insert'
     )
       @connection_config = connection_config
       @output_dir = output_dir
       @config_dir = config_dir
       @dump_target = dump_target
+      @output_format = output_format
       @logger = logger
     end
 
@@ -52,18 +54,30 @@ module Exwiw
           @logger.info("  No records matched. skip this table.")
           next
         end
-        @logger.debug("  Generate INSERT statement...")
-
-        chunk_size = table.bulk_insert_chunk_size
-        chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
-        insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
-
-        @logger.info("  Generated INSERT statement for #{record_num} records (#{chunks.size} statement(s)).")
         insert_idx = (idx + 1).to_s.rjust(3, '0')
-        File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
-          file.puts(insert_sql)
-          post = adapter.post_insert_sql(table)
-          file.puts(post) if post
+
+        if @output_format == 'copy'
+          @logger.debug("  Generate COPY statement...")
+          copy_sql = adapter.to_copy_from_stdin(results, table)
+          @logger.info("  Generated COPY statement for #{record_num} records.")
+
+          File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+            file.puts(copy_sql)
+            post = adapter.post_insert_sql(table)
+            file.puts(post) if post
+          end
+        else
+          @logger.debug("  Generate INSERT statement...")
+          chunk_size = table.bulk_insert_chunk_size
+          chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
+          insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
+
+          @logger.info("  Generated INSERT statement for #{record_num} records (#{chunks.size} statement(s)).")
+          File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+            file.puts(insert_sql)
+            post = adapter.post_insert_sql(table)
+            file.puts(post) if post
+          end
         end
 
         if adapter.supports_bulk_delete?

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -253,6 +253,57 @@ module Exwiw
         end
       end
 
+      describe "#to_copy_from_stdin" do
+        context "simple rows" do
+          let(:results) do
+            [
+              ["1", "Shop 1", "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
+              ["2", "Shop 2", "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
+            ]
+          end
+          let(:copy_sql) { adapter.to_copy_from_stdin(results, shops_table(adapter_name)) }
+
+          it "returns correct COPY FROM stdin block" do
+            expect(copy_sql).to eq(
+              "COPY shops (id, name, updated_at, created_at) FROM stdin;\n" \
+              "1\tShop 1\t2025-01-01 00:00:00\t2025-01-01 00:00:00\n" \
+              "2\tShop 2\t2025-01-01 00:00:00\t2025-01-01 00:00:00\n" \
+              "\\."
+            )
+          end
+        end
+
+        context "with NULL values" do
+          let(:results) do
+            [["1", nil, "2025-01-01 00:00:00", "2025-01-01 00:00:00"]]
+          end
+          let(:copy_sql) { adapter.to_copy_from_stdin(results, shops_table(adapter_name)) }
+
+          it "escapes NULL as \\N" do
+            lines = copy_sql.split("\n")
+            expect(lines[1]).to eq("1\t\\N\t2025-01-01 00:00:00\t2025-01-01 00:00:00")
+          end
+        end
+
+        context "with special characters" do
+          let(:results) do
+            [
+              ["1", "Shop\twith\ttabs", "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
+              ["2", "Shop\\with\\backslash", "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
+              ["3", "Shop\nwith\nnewlines", "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
+            ]
+          end
+          let(:copy_sql) { adapter.to_copy_from_stdin(results, shops_table(adapter_name)) }
+
+          it "escapes tabs, backslashes, and newlines" do
+            lines = copy_sql.split("\n")
+            expect(lines[1]).to include("Shop\\twith\\ttabs")
+            expect(lines[2]).to include("Shop\\\\with\\\\backslash")
+            expect(lines[3]).to include("Shop\\nwith\\nnewlines")
+          end
+        end
+      end
+
       describe "#to_bulk_delete" do
         context "simple select query" do
           let(:bulk_delete_sql) { adapter.to_bulk_delete(build_select_shops_ast, shops_table(adapter_name)) }

--- a/spec/insert_output_snapshot_spec.rb
+++ b/spec/insert_output_snapshot_spec.rb
@@ -83,6 +83,7 @@ module Exwiw
             output_dir: output_dir,
             config_dir: scenario[:config_dir],
             dump_target: DumpTarget.new(table_name: "shops", ids: ["1"]),
+            output_format: scenario.fetch(:output_format, "insert"),
             logger: ::Logger.new(nil),
           )
         end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -89,5 +89,87 @@ module Exwiw
         expect(sql.scan(/INSERT INTO shops/).size).to eq(1)
       end
     end
+    describe 'dump-all mode (no target table or ids)' do
+      let(:config_dir) { 'tmp/runner_spec_config_dumpall' }
+      let(:output_dir) { 'tmp/runner_spec_output_dumpall' }
+      let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: 'scenario/sqlite3-schema',
+          dump_target: dump_target,
+          logger: ::Logger.new(nil),
+        )
+      end
+
+      before do
+        FileUtils.rm_rf(output_dir)
+      end
+
+      it 'writes insert files for all tables without raising' do
+        expect { runner.run }.not_to raise_error
+
+        insert_files = Dir[File.join(output_dir, 'insert-*-*.sql')]
+        expect(insert_files).not_to be_empty
+      end
+    end
+
+    describe 'with output_format copy' do
+      let(:output_dir) { 'tmp/runner_spec_output_copy' }
+      let(:connection_config) do
+        ConnectionConfig.new(
+          adapter: 'postgresql',
+          database_name: 'exwiw_test',
+          host: '127.0.0.1',
+          port: 5432,
+          user: 'postgres',
+          password: 'test_password',
+        )
+      end
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: 'scenario/postgresql-schema',
+          dump_target: dump_target,
+          output_format: 'copy',
+          logger: ::Logger.new(nil),
+        )
+      end
+
+      before do
+        FileUtils.rm_rf(output_dir)
+      end
+
+      it 'generates COPY FROM stdin format instead of INSERT' do
+        runner.run
+
+        sql_file = Dir[File.join(output_dir, 'insert-*-shops.sql')].first
+        expect(sql_file).not_to be_nil
+
+        sql = File.read(sql_file)
+        expect(sql).to include('COPY shops')
+        expect(sql).to include('FROM stdin;')
+        expect(sql).to include('\\.')
+        expect(sql).not_to include('INSERT INTO')
+      end
+
+      it 'still generates post_insert_sql (setval)' do
+        runner.run
+
+        sql_file = Dir[File.join(output_dir, 'insert-*-shops.sql')].first
+        sql = File.read(sql_file)
+        expect(sql).to include('pg_catalog.setval')
+      end
+
+      it 'still generates delete files' do
+        runner.run
+
+        delete_files = Dir[File.join(output_dir, 'delete-*.sql')]
+        expect(delete_files).not_to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `-output-format=copy` で PostgreSQL の `COPY FROM stdin` 形式を出力可能にした : INSERTより高速になることを狙う
- `-target-table` と `-ids` を省略すると、`-config-dir` 内の全テーブルをダンプするモードを追加

## Notes

- `-output-format=copy` は PostgreSQL アダプタのみ対応。他アダプタ指定時はエラー
- マスキングは SELECT クエリ時に適用されるため、COPY 形式でも既存と同様に動作する
- 出力ファイル名は既存の `insert-XXX-` prefix を維持
  - TODO: `copy-` にしても良いかも