### PR TITLE
feat: add --insert-only option to skip DELETE SQL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--insert-only` CLI flag to skip generating `delete-*.sql` files.
+
 ## [0.1.9] - 2026-05-21
 
   Added

--- a/README.md
+++ b/README.md
@@ -160,6 +160,24 @@ psql -d app_dev -f dump/insert-001-shops.sql
 
 `--output-format=copy` is only supported with the `postgresql` adapter.
 
+### Skip DELETE SQL output
+
+By default, exwiw generates `delete-*.sql` files alongside the `insert-*.sql` files so that an existing dataset can be cleared before re-inserting. Pass `--insert-only` when you only need the insert files:
+
+```bash
+exwiw \
+  --adapter=mysql2 \
+  --host=localhost \
+  --port=3306 \
+  --user=reader \
+  --database=app_production \
+  --config-dir=exwiw \
+  --target-table=shops \
+  --ids=1 \
+  --output-dir=dump \
+  --insert-only
+```
+
 ### Bulk insert chunk size
 
 `bulk_insert_chunk_size` splits the generated `INSERT` statement into multiple statements, each containing at most the specified number of rows. This is useful when the number of records per table is large enough to hit limits like MySQL's `max_allowed_packet`.

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -29,6 +29,7 @@ module Exwiw
       @target_table_name = nil
       @ids = []
       @output_format = 'insert'
+      @insert_only = false
       @log_level = :info
 
       parser.parse!(@argv)
@@ -62,6 +63,7 @@ module Exwiw
           config_dir: @config_dir,
           dump_target: dump_target,
           output_format: @output_format,
+          insert_only: @insert_only,
           logger: logger,
         ).run
       end
@@ -167,6 +169,7 @@ module Exwiw
         opts.on("--target-table=[TABLE]", "Target table for extraction. If omitted, dump all tables.") { |v| @target_table_name = v }
         opts.on("--ids=[IDS]", "Comma-separated list of identifiers. Required when --target-table is given.") { |v| @ids = v.split(',') }
         opts.on("--output-format=[FORMAT]", "Output format: insert (default) or copy (PostgreSQL only)") { |v| @output_format = v }
+        opts.on("--insert-only", "Do not generate DELETE SQL files") { @insert_only = true }
         opts.on("--log-level=LEVEL", "Log level (debug, info). default is info") { |v| @log_level = v.to_sym }
 
         opts.on("--help", "Print this help") do

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -10,13 +10,15 @@ module Exwiw
       config_dir:,
       dump_target:,
       logger:,
-      output_format: 'insert'
+      output_format: 'insert',
+      insert_only: false
     )
       @connection_config = connection_config
       @output_dir = output_dir
       @config_dir = config_dir
       @dump_target = dump_target
       @output_format = output_format
+      @insert_only = insert_only
       @logger = logger
     end
 
@@ -80,7 +82,7 @@ module Exwiw
           end
         end
 
-        if adapter.supports_bulk_delete?
+        if adapter.supports_bulk_delete? && !@insert_only
           @logger.debug("  Generate DELETE statement...")
           delete_sql = adapter.to_bulk_delete(query_ast, table)
           if @logger.debug?

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -115,6 +115,40 @@ module Exwiw
       end
     end
 
+    describe 'with insert_only' do
+      let(:config_dir) { 'tmp/runner_spec_config_insert_only' }
+      let(:output_dir) { 'tmp/runner_spec_output_insert_only' }
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: config_dir,
+          dump_target: dump_target,
+          insert_only: true,
+          logger: ::Logger.new(nil),
+        )
+      end
+
+      before do
+        FileUtils.rm_rf(config_dir)
+        FileUtils.rm_rf(output_dir)
+        FileUtils.mkdir_p(config_dir)
+
+        FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
+      end
+
+      it 'does not generate delete files' do
+        runner.run
+
+        insert_files = Dir[File.join(output_dir, 'insert-*-shops.sql')]
+        expect(insert_files).not_to be_empty
+
+        delete_files = Dir[File.join(output_dir, 'delete-*.sql')]
+        expect(delete_files).to be_empty
+      end
+    end
+
     describe 'with output_format copy' do
       let(:output_dir) { 'tmp/runner_spec_output_copy' }
       let(:connection_config) do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'fileutils'
 require 'json'
+require 'tmpdir'
 
 module Exwiw
   RSpec.describe Runner do
@@ -14,8 +15,8 @@ module Exwiw
         password: nil,
       )
     end
-    let(:output_dir) { 'tmp/test_output_dir' }
-    let(:config_dir) { 'test_config' }
+    let(:output_dir) { @output_dir }
+    let(:config_dir) { @config_dir }
     let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
     let(:runner) do
       Runner.new(
@@ -27,21 +28,25 @@ module Exwiw
       )
     end
 
+    around do |example|
+      Dir.mktmpdir do |config|
+        Dir.mktmpdir do |output|
+          @config_dir = config
+          @output_dir = output
+          example.run
+        end
+      end
+    end
+
     it 'writes bulk insert SQL to the output file' do
       expect { runner.run }.not_to raise_error
     end
 
     describe 'with bulk_insert_chunk_size' do
-      let(:config_dir) { 'tmp/runner_spec_config' }
-      let(:output_dir) { 'tmp/runner_spec_output' }
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2', '3', '4', '5']) }
       let(:insert_sql_regex) { /INSERT INTO shops .+ VALUES\n\([^)]+\)(?:,\n\([^)]+\))*;/ }
 
       before do
-        FileUtils.rm_rf(config_dir)
-        FileUtils.rm_rf(output_dir)
-        FileUtils.mkdir_p(config_dir)
-
         shops_config = JSON.parse(File.read('scenario/sqlite3-schema/shops.json'))
         shops_config['bulk_insert_chunk_size'] = 2
         File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops_config))
@@ -67,15 +72,9 @@ module Exwiw
     end
 
     describe 'without bulk_insert_chunk_size' do
-      let(:config_dir) { 'tmp/runner_spec_config_nochunk' }
-      let(:output_dir) { 'tmp/runner_spec_output_nochunk' }
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2', '3', '4', '5']) }
 
       before do
-        FileUtils.rm_rf(config_dir)
-        FileUtils.rm_rf(output_dir)
-        FileUtils.mkdir_p(config_dir)
-
         FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
       end
 
@@ -90,8 +89,6 @@ module Exwiw
       end
     end
     describe 'dump-all mode (no target table or ids)' do
-      let(:config_dir) { 'tmp/runner_spec_config_dumpall' }
-      let(:output_dir) { 'tmp/runner_spec_output_dumpall' }
       let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
       let(:runner) do
         Runner.new(
@@ -103,10 +100,6 @@ module Exwiw
         )
       end
 
-      before do
-        FileUtils.rm_rf(output_dir)
-      end
-
       it 'writes insert files for all tables without raising' do
         expect { runner.run }.not_to raise_error
 
@@ -116,8 +109,6 @@ module Exwiw
     end
 
     describe 'with insert_only' do
-      let(:config_dir) { 'tmp/runner_spec_config_insert_only' }
-      let(:output_dir) { 'tmp/runner_spec_output_insert_only' }
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
       let(:runner) do
         Runner.new(
@@ -131,10 +122,6 @@ module Exwiw
       end
 
       before do
-        FileUtils.rm_rf(config_dir)
-        FileUtils.rm_rf(output_dir)
-        FileUtils.mkdir_p(config_dir)
-
         FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
       end
 
@@ -150,7 +137,6 @@ module Exwiw
     end
 
     describe 'with output_format copy' do
-      let(:output_dir) { 'tmp/runner_spec_output_copy' }
       let(:connection_config) do
         ConnectionConfig.new(
           adapter: 'postgresql',
@@ -171,10 +157,6 @@ module Exwiw
           output_format: 'copy',
           logger: ::Logger.new(nil),
         )
-      end
-
-      before do
-        FileUtils.rm_rf(output_dir)
       end
 
       it 'generates COPY FROM stdin format instead of INSERT' do


### PR DESCRIPTION
## Summary

- Add `--insert-only` CLI flag to `exwiw` that suppresses `delete-*.sql` output and only emits the `insert-*.sql` files.
- Threaded through `Runner#initialize(insert_only:)` and gated the DELETE block accordingly.
- Documented the flag in README and added a CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `bundle exec rspec spec/runner_spec.rb` — added a new "with insert_only" example confirming `delete-*.sql` is not produced while `insert-*.sql` still is.
- [x] `bundle exec exe/exwiw` help output shows `--insert-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)