### PR TITLE
feat: --after-insert-hook オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,47 @@ exwiw \
   --insert-only
 ```
 
+### After-insert hook
+
+`--after-insert-hook=PATH` runs a post-processing hook **after** all per-table insert/delete files have been written. The hook can be either a Ruby file (`.rb`) or any executable script (e.g. `.sh`).
+
+**Ruby hook (`.rb`)**: provides a tiny DSL with two builtins:
+
+- `cli_options` — Hash of all parsed CLI options (e.g. `cli_options.fetch(:ids)` returns the `--ids` array).
+- `insert_sql(template)` — appends an ERB-rendered string to a buffer. After the hook finishes, the buffer is concatenated and written to `insert-{N+1}-after_insert.{ext}` where `{N+1}` is one past the last per-table insert file. For the MongoDB adapter the equivalent alias `insert_jsonl(template)` is available; output goes to `insert-{N+1}-after_insert.jsonl`. Multiple `insert_sql` calls in a single hook are joined with `"\n"` into the same file. If no `insert_sql` call is made, no file is created.
+
+Example `hooks/seed_default_users.rb`:
+
+```ruby
+insert_sql <<~SQL
+  -- seed default users for tenants <%= cli_options.fetch(:ids).join(',') %>
+  <%- cli_options.fetch(:ids).each do |tenant_id| -%>
+  INSERT INTO users (tenant_id, email) VALUES (<%= tenant_id %>, 'default@example.com');
+  <%- end -%>
+SQL
+```
+
+Run with:
+
+```bash
+exwiw \
+  --adapter=mysql2 --host=localhost --port=3306 --user=reader \
+  --database=app_production --config-dir=exwiw \
+  --target-table=shops --ids=1,2 \
+  --output-dir=dump \
+  --after-insert-hook=hooks/seed_default_users.rb
+```
+
+**Shell hook**: anything other than `.rb` is exec'd as a child process. It is a pure side-effect hook — exwiw does not capture its stdout. The hook receives these env vars and inherits `DATABASE_PASSWORD` from the parent:
+
+- `EXWIW_OUTPUT_DIR`, `EXWIW_CONFIG_DIR`
+- `EXWIW_DATABASE_ADAPTER`, `EXWIW_DATABASE_HOST`, `EXWIW_DATABASE_PORT`, `EXWIW_DATABASE_USER`, `EXWIW_DATABASE_NAME`
+- `EXWIW_TARGET_TABLE`, `EXWIW_IDS` (comma-separated), `EXWIW_OUTPUT_FORMAT`
+
+A non-zero exit code from the shell hook aborts exwiw.
+
+Note: Ruby hooks are evaluated via `instance_eval` inside the exwiw process — only pass paths you trust.
+
 ### Bulk insert chunk size
 
 `bulk_insert_chunk_size` splits the generated `INSERT` statement into multiple statements, each containing at most the specified number of rows. This is useful when the number of records per table is large enough to hit limits like MySQL's `max_allowed_packet`.

--- a/docs/plans/2026-05-22-after-insert-hook.md
+++ b/docs/plans/2026-05-22-after-insert-hook.md
@@ -1,0 +1,189 @@
+# Plan: `--after-insert-hook` フック (Ruby DSL / shell script)
+
+## Context
+
+現状 `exwiw` は `insert-000-schema.{sql,js}` → `insert-NNN-{table}.{sql,jsonl}` → `delete-NNN-...` を生成して終わる。実運用では「import 後に特定テナントへデフォルトユーザを挿入する」「監査ログを 1 行打つ」など、抽出結果を踏まえた**後処理 SQL / 副作用**を続けて流したいケースがある。
+
+これを毎回別ファイルとして手で書き足すのは面倒なので、抽出ジョブの一部としてフックを記述できるようにする。フックは `--ids` などの CLI オプションを参照できるべき (例: 「抽出対象のテナント ID 配列に対してデフォルトユーザを seed」)。
+
+ゴール:
+
+- `--after-insert=PATH` オプションを追加。`PATH` には `.rb` または `.sh` を指定可。
+- 拡張子 `.rb`: 軽量 DSL (`cli_options`, `insert_sql` / `insert_jsonl`) を提供。文字列引数は ERB として評価され、結果が連結されて最後尾の insert ファイルとして書き出される。
+- 拡張子 `.sh` (および `.rb` 以外): 環境変数で CLI オプションを渡したうえで子プロセスとして実行。出力ファイルは生成しない (純粋な副作用フック)。
+- フックは per-table の insert/delete ループ完了後に 1 度だけ実行される。
+
+## Design
+
+### CLI レイヤー
+**File**: `lib/exwiw/cli.rb`
+
+- `@after_insert_path = nil` を初期化 (`initialize`)。
+- `parser` 内に `opts.on("--after-insert=[PATH]", "Path to a .rb or .sh post-processing hook") { |v| @after_insert_path = File.expand_path(v) }` を追加。
+- `validate_options!` で以下を検証:
+  - パスが存在しないとき: `$stderr.puts "--after-insert file not found: #{@after_insert_path}"; exit 1`
+  - 拡張子が `.rb` でも `.sh` でもなく、かつ実行可能ビットも立っていないとき: `--after-insert must be a .rb file or an executable script` で exit 1。
+- `cli_options` 用に **CLI 全オプションを Hash 化するメソッド** を追加 (`build_cli_options_hash`):
+  ```ruby
+  {
+    database_host: @database_host, database_port: @database_port,
+    database_user: @database_user, database_password: @database_password,
+    output_dir: @output_dir, config_dir: @config_dir,
+    database_adapter: @database_adapter, database_name: @database_name,
+    target_table: @target_table_name, ids: @ids.dup.freeze,
+    output_format: @output_format, insert_only: @insert_only,
+    log_level: @log_level, after_insert: @after_insert_path,
+  }.freeze
+  ```
+- `Runner.new(...)` 呼び出しに `after_insert_path: @after_insert_path, cli_options: build_cli_options_hash` を追加。
+
+### Runner 統合
+**File**: `lib/exwiw/runner.rb`
+
+- `initialize` のキーワード引数に `after_insert_path: nil, cli_options: {}` を追加し instance var に格納。
+- `run` の per-table ループ (`ordered_table_names.each_with_index`) が終わった**直後** (現状の line 98 の直後) で:
+  ```ruby
+  if @after_insert_path
+    @logger.info("Running after-insert hook: #{@after_insert_path}")
+    AfterInsertHook.run(
+      path: @after_insert_path,
+      cli_options: @cli_options,
+      output_dir: @output_dir,
+      next_idx: total_size + 1,
+      output_extension: adapter.output_extension,
+      logger: @logger,
+    )
+  end
+  ```
+- `total_size` は既存変数 (`ordered_table_names.size`)。schema が `000`、per-table が `001..total_size` を使うので、フック出力は `total_size + 1` 番。`delete-*` は逆順番号なので衝突しない。
+
+### 新規ファイル: `lib/exwiw/after_insert_hook.rb`
+
+```ruby
+require 'erb'
+require 'shellwords'
+
+module Exwiw
+  class AfterInsertHook
+    def self.run(path:, cli_options:, output_dir:, next_idx:, output_extension:, logger:)
+      ext = File.extname(path)
+      idx_str = next_idx.to_s.rjust(3, '0')
+      output_path = File.join(output_dir, "insert-#{idx_str}-after_insert.#{output_extension}")
+
+      case ext
+      when '.rb'
+        run_ruby(path: path, cli_options: cli_options, output_path: output_path, logger: logger)
+      else
+        run_shell(path: path, cli_options: cli_options, output_dir: output_dir, logger: logger)
+      end
+    end
+
+    def self.run_ruby(path:, cli_options:, output_path:, logger:)
+      ctx = Context.new(cli_options)
+      ctx.instance_eval(File.read(path), path)
+      sql = ctx.collected.join("\n")
+      if sql.empty?
+        logger.info("After-insert hook produced no output; skipping file write.")
+        return
+      end
+      File.write(output_path, sql)
+      logger.info("Wrote after-insert hook output to #{output_path}")
+    end
+
+    def self.run_shell(path:, cli_options:, output_dir:, logger:)
+      env = {
+        'EXWIW_OUTPUT_DIR'       => output_dir,
+        'EXWIW_CONFIG_DIR'       => cli_options[:config_dir].to_s,
+        'EXWIW_DATABASE_ADAPTER' => cli_options[:database_adapter].to_s,
+        'EXWIW_DATABASE_HOST'    => cli_options[:database_host].to_s,
+        'EXWIW_DATABASE_PORT'    => cli_options[:database_port].to_s,
+        'EXWIW_DATABASE_USER'    => cli_options[:database_user].to_s,
+        'EXWIW_DATABASE_NAME'    => cli_options[:database_name].to_s,
+        'EXWIW_TARGET_TABLE'     => cli_options[:target_table].to_s,
+        'EXWIW_IDS'              => Array(cli_options[:ids]).join(','),
+        'EXWIW_OUTPUT_FORMAT'    => cli_options[:output_format].to_s,
+      }
+      # DATABASE_PASSWORD は既存 ENV をそのまま受け継がせる (env hash で上書きしない)。
+      ok = system(env, path)
+      raise "after-insert shell hook failed: #{path}" unless ok
+    end
+
+    class Context
+      attr_reader :cli_options, :collected
+
+      def initialize(cli_options)
+        @cli_options = cli_options
+        @collected = []
+      end
+
+      # ERB 評価。MongoDB 向けに `insert_jsonl` の別名も提供する (出力ファイル名・拡張子は
+      # Runner 側で adapter.output_extension を元に決まるので、どちらを呼んでも同じバッファに溜まる)。
+      def insert_sql(template)
+        @collected << ERB.new(template, trim_mode: '-').result(binding)
+      end
+      alias_method :insert_jsonl, :insert_sql
+    end
+  end
+end
+```
+
+ポイント:
+- `instance_eval(File.read(path), path)` で、フックファイル内では `cli_options` と `insert_sql` が単純なメソッド呼び出しとして使える (DSL 風)。
+- ERB 評価は `Context#insert_sql` の `binding` を使うため、ERB テンプレート内でも `cli_options.fetch(:ids)` が呼べる。
+- `insert_sql` / `insert_jsonl` を複数回呼ぶと `@collected` に積まれ、最後に `"\n"` で連結して 1 ファイルに書く。
+- 空出力なら書き出さない (idempotency に近い挙動)。
+- shell 実行は `system(env, path)`。`path` は単独引数として渡すのでシェル展開されない (Shellwords 必要なし)。失敗時は exception で停止 → exit。
+- ENV 名は `EXWIW_*` 接頭辞で名前空間を切る。`DATABASE_PASSWORD` は親プロセスの ENV を継承させる (フック側で読みたければ読める)。
+
+### lib/exwiw.rb への require 追加
+`require_relative "exwiw/after_insert_hook"` を `runner.rb` の require の前後あたりに追加。
+
+### 使用例 (README に追記)
+
+`hooks/seed_default_users.rb`:
+```ruby
+# cli_options[:ids] には --ids で渡された配列が入る
+insert_sql <<~SQL
+  -- seed default users for tenants <%= cli_options.fetch(:ids).join(',') %>
+  <%- cli_options.fetch(:ids).each do |tenant_id| -%>
+  INSERT INTO users (tenant_id, email) VALUES (<%= tenant_id %>, 'default@example.com');
+  <%- end -%>
+SQL
+```
+
+実行:
+```
+exwiw --adapter=mysql2 ... --target-table=shops --ids=1,2 \
+  --after-insert=hooks/seed_default_users.rb
+```
+結果: `dump/insert-{total+1}-after_insert.sql` が、テナント 1,2 用の INSERT を含めて出力される。
+
+## Files to modify / add
+
+| パス | 変更 |
+|---|---|
+| `lib/exwiw/cli.rb` | `--after-insert` parse / validate / `build_cli_options_hash` 追加、Runner 呼び出しへ伝搬 |
+| `lib/exwiw/runner.rb` | `initialize` に `after_insert_path:`, `cli_options:` 追加、per-table ループ完了後にフック呼び出し |
+| `lib/exwiw/after_insert_hook.rb` (新規) | `AfterInsertHook.run` + `Context` (DSL + ERB) |
+| `lib/exwiw.rb` | `require_relative "exwiw/after_insert_hook"` 追加 |
+| `README.md` | `--after-insert` の節を追加 (Ruby DSL 例 / shell hook 例 / 環境変数一覧) |
+| `spec/runner_spec.rb` | Ruby フックで `insert-{N+1}-after_insert.sql` が書き出され、ERB で `cli_options.fetch(:ids)` が展開されることを assert |
+| `spec/after_insert_hook_spec.rb` (新規) | `Context#insert_sql` の ERB 評価、複数回呼び出しが `"\n"` 連結されることを assert |
+
+## Verification
+
+1. **ユニットテスト**: `bundle exec rspec spec/after_insert_hook_spec.rb` — `Context#insert_sql` を直接叩いて、ERB が `cli_options.fetch(:ids)` を解決できること、複数回呼び出しが `\n` 連結されることを確認。
+2. **統合テスト**: `bundle exec rspec spec/runner_spec.rb` — sqlite3 経由で実際に Runner を流し、tmp に書いたフック `.rb` を `--after-insert` 相当で渡し、`tmp/.../insert-{N+1}-after_insert.sql` が生成されることと、ファイル内に ERB 展開後の `--ids` の値が含まれることを assert。
+3. **CLI E2E**: scenario の `test_with_sqlite3.sh` を一時的に編集して `--after-insert=` を付けた呼び出しを試し、出力ディレクトリに想定どおりのファイルが置かれることを目視確認。MongoDB は `--after-insert=hook.rb` で `insert_jsonl` を使ったときに `.jsonl` が出ることのみ smoke-test。
+4. **エッジケース確認**:
+   - `--after-insert=missing.rb` でわかりやすいエラー終了。
+   - フック内で `insert_sql` を 1 度も呼ばなかったとき、ファイルは作られず info ログのみ。
+   - shell hook の non-zero exit code で Runner が落ちる。
+   - `--ids` 省略時に `cli_options.fetch(:ids)` が空配列を返す (`@ids = []` 初期値が保たれる)。
+
+## 留意点 / 既知のリスク
+
+- **任意コード実行**: `.rb` フックは `instance_eval` で実行される (= exwiw プロセスと同じ権限で動く)。ユーザ自身が用意した hook を渡す前提なので問題ないが、README に「信頼するソースのみ」と注意書きを入れる。
+- **ファイル番号の衝突**: `delete-*` は逆順番号 (`total_size - idx`) を使うので、`insert-{total+1}-after_insert` と直接衝突はしない (`delete-001`...`delete-{total}` の範囲)。
+- **MongoDB 対応の限界**: `insert_jsonl` は ERB 出力結果を `.jsonl` としてそのまま書き出す。1 行 1 ドキュメントの形に揃えるのはユーザ責任。`mongoimport` で流せる前提。
+- **password の取り扱い**: shell hook の env に `DATABASE_PASSWORD` を明示的に詰めない (親プロセス ENV を継承させる)。プロセス一覧経由の漏えいを防ぐため、ENV を介すのは hash で `EXWIW_*` のみ。

--- a/lib/exwiw.rb
+++ b/lib/exwiw.rb
@@ -21,6 +21,7 @@ require_relative "exwiw/determine_table_processing_order"
 require_relative "exwiw/mongo_query"
 require_relative "exwiw/query_ast"
 require_relative "exwiw/query_ast_builder"
+require_relative "exwiw/after_insert_hook"
 require_relative "exwiw/runner"
 require_relative "exwiw/schema_generator"
 

--- a/lib/exwiw/after_insert_hook.rb
+++ b/lib/exwiw/after_insert_hook.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'erb'
+
+module Exwiw
+  class AfterInsertHook
+    def self.run(path:, cli_options:, output_dir:, next_idx:, output_extension:, logger:)
+      ext = File.extname(path)
+      idx_str = next_idx.to_s.rjust(3, '0')
+      output_path = File.join(output_dir, "insert-#{idx_str}-after_insert.#{output_extension}")
+
+      if ext == '.rb'
+        run_ruby(path: path, cli_options: cli_options, output_path: output_path, logger: logger)
+      else
+        run_shell(path: path, cli_options: cli_options, output_dir: output_dir, logger: logger)
+      end
+    end
+
+    def self.run_ruby(path:, cli_options:, output_path:, logger:)
+      ctx = Context.new(cli_options)
+      ctx.instance_eval(File.read(path), path)
+      content = ctx.collected.join("\n")
+      if content.empty?
+        logger.info("After-insert hook produced no output; skipping file write.")
+        return
+      end
+      File.write(output_path, content)
+      logger.info("Wrote after-insert hook output to #{output_path}")
+    end
+
+    def self.run_shell(path:, cli_options:, output_dir:, logger:)
+      env = {
+        'EXWIW_OUTPUT_DIR'       => output_dir,
+        'EXWIW_CONFIG_DIR'       => cli_options[:config_dir].to_s,
+        'EXWIW_DATABASE_ADAPTER' => cli_options[:database_adapter].to_s,
+        'EXWIW_DATABASE_HOST'    => cli_options[:database_host].to_s,
+        'EXWIW_DATABASE_PORT'    => cli_options[:database_port].to_s,
+        'EXWIW_DATABASE_USER'    => cli_options[:database_user].to_s,
+        'EXWIW_DATABASE_NAME'    => cli_options[:database_name].to_s,
+        'EXWIW_TARGET_TABLE'     => cli_options[:target_table].to_s,
+        'EXWIW_IDS'              => Array(cli_options[:ids]).join(','),
+        'EXWIW_OUTPUT_FORMAT'    => cli_options[:output_format].to_s,
+      }
+      logger.info("Running after-insert shell hook: #{path}")
+      ok = system(env, path)
+      raise "after-insert shell hook failed: #{path}" unless ok
+    end
+
+    class Context
+      attr_reader :cli_options, :collected
+
+      def initialize(cli_options)
+        @cli_options = cli_options
+        @collected = []
+      end
+
+      def insert_sql(template)
+        @collected << ERB.new(template, trim_mode: '-').result(binding)
+      end
+      alias_method :insert_jsonl, :insert_sql
+    end
+  end
+end

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -30,6 +30,7 @@ module Exwiw
       @ids = []
       @output_format = 'insert'
       @insert_only = false
+      @after_insert_hook_path = nil
       @log_level = :info
 
       parser.parse!(@argv)
@@ -64,6 +65,8 @@ module Exwiw
           dump_target: dump_target,
           output_format: @output_format,
           insert_only: @insert_only,
+          after_insert_hook_path: @after_insert_hook_path,
+          cli_options: build_cli_options_hash,
           logger: logger,
         ).run
       end
@@ -131,6 +134,38 @@ module Exwiw
         $stderr.puts "--target-table is required when --ids is specified"
         exit 1
       end
+
+      if @after_insert_hook_path
+        unless File.file?(@after_insert_hook_path)
+          $stderr.puts "--after-insert-hook file not found: #{@after_insert_hook_path}"
+          exit 1
+        end
+
+        ext = File.extname(@after_insert_hook_path)
+        if ext != '.rb' && !File.executable?(@after_insert_hook_path)
+          $stderr.puts "--after-insert-hook must be a .rb file or an executable script: #{@after_insert_hook_path}"
+          exit 1
+        end
+      end
+    end
+
+    private def build_cli_options_hash
+      {
+        database_host: @database_host,
+        database_port: @database_port,
+        database_user: @database_user,
+        database_password: @database_password,
+        output_dir: @output_dir,
+        config_dir: @config_dir,
+        database_adapter: @database_adapter,
+        database_name: @database_name,
+        target_table: @target_table_name,
+        ids: @ids.dup.freeze,
+        output_format: @output_format,
+        insert_only: @insert_only,
+        log_level: @log_level,
+        after_insert_hook: @after_insert_hook_path,
+      }.freeze
     end
 
     private def build_logger
@@ -170,6 +205,9 @@ module Exwiw
         opts.on("--ids=[IDS]", "Comma-separated list of identifiers. Required when --target-table is given.") { |v| @ids = v.split(',') }
         opts.on("--output-format=[FORMAT]", "Output format: insert (default) or copy (PostgreSQL only)") { |v| @output_format = v }
         opts.on("--insert-only", "Do not generate DELETE SQL files") { @insert_only = true }
+        opts.on("--after-insert-hook=PATH", "Path to a .rb or .sh post-processing hook executed after all insert/delete files are written") do |v|
+          @after_insert_hook_path = File.expand_path(v)
+        end
         opts.on("--log-level=LEVEL", "Log level (debug, info). default is info") { |v| @log_level = v.to_sym }
 
         opts.on("--help", "Print this help") do

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -11,7 +11,9 @@ module Exwiw
       dump_target:,
       logger:,
       output_format: 'insert',
-      insert_only: false
+      insert_only: false,
+      after_insert_hook_path: nil,
+      cli_options: {}
     )
       @connection_config = connection_config
       @output_dir = output_dir
@@ -19,6 +21,8 @@ module Exwiw
       @dump_target = dump_target
       @output_format = output_format
       @insert_only = insert_only
+      @after_insert_hook_path = after_insert_hook_path
+      @cli_options = cli_options
       @logger = logger
     end
 
@@ -95,6 +99,18 @@ module Exwiw
             file.puts(delete_sql)
           end
         end
+      end
+
+      if @after_insert_hook_path
+        @logger.info("Running after-insert hook: #{@after_insert_hook_path}")
+        AfterInsertHook.run(
+          path: @after_insert_hook_path,
+          cli_options: @cli_options,
+          output_dir: @output_dir,
+          next_idx: total_size + 1,
+          output_extension: adapter.output_extension,
+          logger: @logger,
+        )
       end
     end
 

--- a/spec/after_insert_hook_spec.rb
+++ b/spec/after_insert_hook_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+require 'fileutils'
+require 'tempfile'
+
+module Exwiw
+  RSpec.describe AfterInsertHook do
+    let(:logger) { ::Logger.new(nil) }
+
+    describe AfterInsertHook::Context do
+      let(:cli_options) { { ids: ['1', '2', '3'], target_table: 'shops' } }
+      let(:ctx) { described_class.new(cli_options) }
+
+      it 'evaluates the template as ERB and exposes cli_options' do
+        ctx.insert_sql("ids=<%= cli_options.fetch(:ids).join(',') %>")
+        expect(ctx.collected).to eq(['ids=1,2,3'])
+      end
+
+      it 'concatenates multiple insert_sql calls' do
+        ctx.insert_sql('A')
+        ctx.insert_sql('B')
+        expect(ctx.collected).to eq(['A', 'B'])
+      end
+
+      it 'aliases insert_jsonl to insert_sql' do
+        ctx.insert_jsonl('{"x":<%= cli_options.fetch(:ids).first %>}')
+        expect(ctx.collected).to eq(['{"x":1}'])
+      end
+    end
+
+    describe '.run with a .rb hook' do
+      let(:output_dir) { 'tmp/after_insert_hook_spec_output' }
+      let(:hook_path) { File.join(output_dir, 'hook.rb') }
+      let(:cli_options) { { ids: ['10', '20'], target_table: 'shops' } }
+
+      before do
+        FileUtils.rm_rf(output_dir)
+        FileUtils.mkdir_p(output_dir)
+        File.write(hook_path, <<~RUBY)
+          insert_sql <<~SQL
+            -- ids: <%= cli_options.fetch(:ids).join(',') %>
+            <%- cli_options.fetch(:ids).each do |id| -%>
+            INSERT INTO defaults (tenant_id) VALUES (<%= id %>);
+            <%- end -%>
+          SQL
+        RUBY
+      end
+
+      it 'writes the next-numbered insert file with ERB-expanded contents' do
+        AfterInsertHook.run(
+          path: hook_path,
+          cli_options: cli_options,
+          output_dir: output_dir,
+          next_idx: 4,
+          output_extension: 'sql',
+          logger: logger,
+        )
+
+        out = File.join(output_dir, 'insert-004-after_insert.sql')
+        expect(File.exist?(out)).to be(true)
+        content = File.read(out)
+        expect(content).to include('-- ids: 10,20')
+        expect(content).to include('INSERT INTO defaults (tenant_id) VALUES (10);')
+        expect(content).to include('INSERT INTO defaults (tenant_id) VALUES (20);')
+      end
+
+      it 'does not create a file when insert_sql is never called' do
+        File.write(hook_path, "# noop\n")
+
+        AfterInsertHook.run(
+          path: hook_path,
+          cli_options: cli_options,
+          output_dir: output_dir,
+          next_idx: 7,
+          output_extension: 'sql',
+          logger: logger,
+        )
+
+        expect(Dir[File.join(output_dir, 'insert-*-after_insert.sql')]).to be_empty
+      end
+    end
+
+    describe '.run with a shell hook' do
+      let(:output_dir) { 'tmp/after_insert_hook_spec_shell' }
+      let(:hook_path) { File.join(output_dir, 'hook.sh') }
+      let(:cli_options) do
+        {
+          ids: ['1', '2'], target_table: 'shops', config_dir: '/cfg',
+          database_adapter: 'sqlite3', database_host: nil, database_port: nil,
+          database_user: nil, database_name: 'db', output_format: 'insert',
+        }
+      end
+
+      before do
+        FileUtils.rm_rf(output_dir)
+        FileUtils.mkdir_p(output_dir)
+        File.write(hook_path, <<~SH)
+          #!/usr/bin/env bash
+          set -eu
+          echo "ids=$EXWIW_IDS table=$EXWIW_TARGET_TABLE adapter=$EXWIW_DATABASE_ADAPTER" \\
+            > "$EXWIW_OUTPUT_DIR/shell_out.txt"
+        SH
+        FileUtils.chmod(0o755, hook_path)
+      end
+
+      it 'executes the shell script with EXWIW_* env vars' do
+        AfterInsertHook.run(
+          path: hook_path,
+          cli_options: cli_options,
+          output_dir: output_dir,
+          next_idx: 5,
+          output_extension: 'sql',
+          logger: logger,
+        )
+
+        out = File.read(File.join(output_dir, 'shell_out.txt'))
+        expect(out).to include('ids=1,2')
+        expect(out).to include('table=shops')
+        expect(out).to include('adapter=sqlite3')
+      end
+
+      it 'raises when the shell hook exits non-zero' do
+        File.write(hook_path, "#!/usr/bin/env bash\nexit 7\n")
+        FileUtils.chmod(0o755, hook_path)
+
+        expect {
+          AfterInsertHook.run(
+            path: hook_path,
+            cli_options: cli_options,
+            output_dir: output_dir,
+            next_idx: 5,
+            output_extension: 'sql',
+            logger: logger,
+          )
+        }.to raise_error(/after-insert shell hook failed/)
+      end
+    end
+  end
+end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -136,6 +136,45 @@ module Exwiw
       end
     end
 
+    describe 'with after_insert_hook_path (.rb)' do
+      let(:hook_path) { 'tmp/runner_spec_after_hook.rb' }
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2']) }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: config_dir,
+          dump_target: dump_target,
+          after_insert_hook_path: hook_path,
+          cli_options: { ids: ['1', '2'], target_table: 'shops' },
+          logger: ::Logger.new(nil),
+        )
+      end
+
+      before do
+        FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
+
+        File.write(hook_path, <<~RUBY)
+          insert_sql <<~SQL
+            -- after-insert for ids: <%= cli_options.fetch(:ids).join(',') %>
+          SQL
+        RUBY
+      end
+
+      after do
+        FileUtils.rm_f(hook_path)
+      end
+
+      it 'writes insert-{N+1}-after_insert.sql with ERB-expanded content' do
+        runner.run
+
+        files = Dir[File.join(output_dir, 'insert-*-after_insert.sql')]
+        expect(files.size).to eq(1)
+        content = File.read(files.first)
+        expect(content).to include('-- after-insert for ids: 1,2')
+      end
+    end
+
     describe 'with output_format copy' do
       let(:connection_config) do
         ConnectionConfig.new(


### PR DESCRIPTION
## Summary

- `--after-insert-hook=PATH` を追加し、per-table の insert/delete ファイル生成後に走る後処理フックを実行できるようにした
- `.rb` フックは `cli_options` / `insert_sql` (MongoDB 向け alias `insert_jsonl`) DSL を提供。引数は ERB 評価され、結果が連結されて `insert-{N+1}-after_insert.{ext}` に書き出される
- `.rb` 以外は `EXWIW_*` 環境変数を渡して子プロセスとして実行する純粋な副作用フック (stdout はキャプチャしない / 非ゼロ exit で停止)

## Test plan

- [x] \`bundle exec rspec spec/after_insert_hook_spec.rb\` — Context の ERB 評価・複数回呼び出しの連結・shell hook の env と非ゼロ exit が pass
- [x] \`bundle exec rspec spec/runner_spec.rb\` — Runner 経由で \`insert-{N+1}-after_insert.sql\` が生成され ERB 展開後の \`--ids\` 値が含まれること
- [x] \`bundle exec rspec\` 全体 — 169 examples / 0 failures / 1 pending (既存の pending のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)