### PR TITLE
feat: テーブル設定に skip:true を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `skip: true` table config attribute to explicitly exclude a table from the dump. Skipped tables produce no schema entry, no `insert-*` file, and no `delete-*` file. Using a skipped table as `--target-table`, or having another non-skipped table reference it via `belongs_to`, raises `ArgumentError` on load. Available for both SQL adapters (`TableConfig`) and the MongoDB adapter (`MongodbCollectionConfig`).
+
 ## [0.2.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ A non-zero exit code from the shell hook aborts exwiw.
 
 Note: Ruby hooks are evaluated via `instance_eval` inside the exwiw process — only pass paths you trust.
 
+### Skip a table
+
+Set `"skip": true` on a table's config JSON to explicitly exclude it from the dump. The table is omitted from `insert-000-schema.{sql,js}`, and no `insert-*` / `delete-*` files are generated for it. Skipped tables are also not queried at all.
+
+```json
+{
+  "name": "audit_logs",
+  "primary_key": "id",
+  "skip": true,
+  "belongs_tos": [],
+  "columns": [{ "name": "id" }]
+}
+```
+
+Constraints:
+
+- If another non-skipped table has a `belongs_to` entry pointing at a skipped table, exwiw raises `ArgumentError` on load. Remove the `belongs_to` entry on the referencing table, or unset `skip` on the referenced table.
+- Specifying a skipped table as `--target-table` raises `ArgumentError`.
+- `skip: true` is preserved by `exwiw:schema:generate` regenerations (the receiver value wins over the auto-generated config).
+
 ### Bulk insert chunk size
 
 `bulk_insert_chunk_size` splits the generated `INSERT` statement into multiple statements, each containing at most the specified number of rows. This is useful when the number of records per table is large enough to hit limits like MySQL's `max_allowed_packet`.

--- a/lib/exwiw/mongodb_collection_config.rb
+++ b/lib/exwiw/mongodb_collection_config.rb
@@ -13,6 +13,7 @@ module Exwiw
     attribute :belongs_tos, array(BelongsTo)
     attribute :fields, array(MongodbField)
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
+    attribute :skip, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     # Marks this config as physically embedded inside another collection's
     # documents. When set, this config is not processed as a standalone dump

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -30,6 +30,8 @@ module Exwiw
       adapter = Adapter.build(@connection_config, @logger)
       configs = load_table_config(adapter.class.table_config_class)
 
+      configs = reject_and_validate_skipped(configs)
+
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
       target = table_by_name[@dump_target.table_name]
@@ -119,6 +121,32 @@ module Exwiw
         json = JSON.parse(File.read(file))
         klass.from(json)
       end
+    end
+
+    private def reject_and_validate_skipped(configs)
+      skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
+      return configs if skipped_names.empty?
+
+      configs.each do |config|
+        next if config.skip
+        next unless config.respond_to?(:belongs_tos)
+
+        dangling = config.belongs_tos.select { |rel| skipped_names.include?(rel.table_name) }
+        next if dangling.empty?
+
+        raise ArgumentError,
+              "Table '#{config.name}' has belongs_to references to skipped table(s): " \
+              "#{dangling.map(&:table_name).join(', ')}. " \
+              "Remove the belongs_to entries or unset `skip` on the referenced table."
+      end
+
+      if @dump_target.table_name && skipped_names.include?(@dump_target.table_name)
+        raise ArgumentError,
+              "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
+      end
+
+      skipped_names.each { |n| @logger.info("Skipping table '#{n}' (skip:true)") }
+      configs.reject { |c| c.skip }
     end
   end
 end

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -10,6 +10,7 @@ module Exwiw
     attribute :belongs_tos, array(BelongsTo)
     attribute :columns, array(TableColumn)
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
+    attribute :skip, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     def self.from_symbol_keys(hash)
       from(JSON.parse(hash.to_json))
@@ -76,6 +77,7 @@ module Exwiw
         merged_table.filter = filter
         merged_table.belongs_tos = passed_table.belongs_tos
         merged_table.bulk_insert_chunk_size = passed_table.bulk_insert_chunk_size
+        merged_table.skip = skip
 
         receiver_column_by_name = columns.each_with_object({}) { |column, hash| hash[column.name] = column }
 

--- a/spec/mongodb_collection_config_spec.rb
+++ b/spec/mongodb_collection_config_spec.rb
@@ -78,6 +78,24 @@ module Exwiw
         end
       end
 
+      context 'with skip:true' do
+        let(:json) do
+          {
+            "name" => "logs",
+            "primary_key" => "_id",
+            "skip" => true,
+            "belongs_tos" => [],
+            "fields" => [{ "name" => "_id" }],
+          }
+        end
+
+        it 'loads skip and round-trips through to_hash' do
+          config = described_class.from(json)
+          expect(config.skip).to eq(true)
+          expect(config.to_hash["skip"]).to eq(true)
+        end
+      end
+
       context 'when fields contain raw_sql key' do
         let(:json) do
           {

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -175,6 +175,64 @@ module Exwiw
       end
     end
 
+    describe 'with skip:true on a table config' do
+      let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
+
+      before do
+        FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
+
+        announcements = JSON.parse(File.read('scenario/sqlite3-schema/system_announcements.json'))
+        announcements['skip'] = true
+        File.write(File.join(config_dir, 'system_announcements.json'), JSON.dump(announcements))
+      end
+
+      it 'does not emit schema, insert, or delete files for the skipped table' do
+        runner.run
+
+        expect(Dir[File.join(output_dir, 'insert-*-system_announcements.sql')]).to be_empty
+        expect(Dir[File.join(output_dir, 'delete-*-system_announcements.sql')]).to be_empty
+
+        schema_file = File.join(output_dir, 'insert-000-schema.sql')
+        expect(File.exist?(schema_file)).to be(true)
+        expect(File.read(schema_file)).not_to include('system_announcements')
+      end
+
+      it 'still emits files for non-skipped tables' do
+        runner.run
+
+        expect(Dir[File.join(output_dir, 'insert-*-shops.sql')]).not_to be_empty
+      end
+    end
+
+    describe 'when a non-skipped table has belongs_to a skipped table' do
+      let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
+
+      before do
+        shops = JSON.parse(File.read('scenario/sqlite3-schema/shops.json'))
+        shops['skip'] = true
+        File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
+        FileUtils.cp('scenario/sqlite3-schema/users.json', File.join(config_dir, 'users.json'))
+      end
+
+      it 'raises ArgumentError with a clear message' do
+        expect { runner.run }.to raise_error(ArgumentError, /belongs_to references to skipped table\(s\): shops/)
+      end
+    end
+
+    describe 'when --target-table is skipped' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+      before do
+        shops = JSON.parse(File.read('scenario/sqlite3-schema/shops.json'))
+        shops['skip'] = true
+        File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
+      end
+
+      it 'raises ArgumentError' do
+        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked skip:true/)
+      end
+    end
+
     describe 'with output_format copy' do
       let(:connection_config) do
         ConnectionConfig.new(

--- a/spec/table_config_spec.rb
+++ b/spec/table_config_spec.rb
@@ -121,6 +121,22 @@ module Exwiw
         end
       end
 
+      context 'when receiver has skip:true' do
+        let(:current_config) do
+          TableConfig.from_symbol_keys(
+            name: 'users',
+            primary_key: 'id',
+            skip: true,
+            belongs_tos: current_belongs_tos,
+            columns: current_columns,
+          )
+        end
+
+        it 'preserves skip from the receiver in the merged config' do
+          expect(merged_config.skip).to eq(true)
+        end
+      end
+
       context 'when passed config has less columns' do
         let(:current_columns) do
           [{ name: 'id' }, { name: 'name', replace_with: 'MaskedName{id}' }, { name: 'email' }]


### PR DESCRIPTION
## Summary

- TableConfig / MongodbCollectionConfig に `skip` 属性を追加し、`true` のテーブルを明示的にダンプ対象から除外
- skip されたテーブルは `insert-000-schema.{sql,js}`、`insert-*`、`delete-*` のいずれにも出力されず、クエリも投げない
- skip されたテーブルを他テーブルが `belongs_to` で参照していたり、`--target-table` に指定された場合は Runner ロード時に `ArgumentError` で fail-fast

## 実装メモ

- Serdes 0.1.5 の `optional(Boolean)` が `OptionalType#permit?` の挙動で機能しないため、`Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean))` と明示的にラップして回避
- `TableConfig#merge` は `skip` を receiver 側から保持するため、`exwiw:schema:generate` 再生成でもユーザー設定が消えない

## Test plan

- [x] `bundle exec rake spec` — 175 examples, 0 failures
- [ ] skip:true なテーブルのみ含む scenario でダンプし、schema にも insert にも delete にも当該テーブルが出ないこと
- [ ] 他テーブルが belongs_to で参照しているときに ArgumentError が出ること
- [ ] --target-table に skipped テーブルを指定したときに ArgumentError が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)