### PR TITLE
feat: explain サブコマンドを追加

### DIFF
--- a/.github/workflows/scenario.yml
+++ b/.github/workflows/scenario.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run exwiw (from clean target DB)
         run: scenario/test_with_sqlite3_from_clean.sh
 
+      - name: Run exwiw (explain)
+        run: scenario/test_explain_with_sqlite3.sh
+
   with_mysql:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -63,6 +66,9 @@ jobs:
 
       - name: Run exwiw (from clean target DB)
         run: scenario/test_with_mysql2_from_clean.sh
+
+      - name: Run exwiw (explain)
+        run: scenario/test_explain_with_mysql2.sh
 
   with_postgres:
     runs-on: ubuntu-latest
@@ -116,6 +122,9 @@ jobs:
 
       - name: Run exwiw (copy mode)
         run: scenario/test_with_postgresql_copy.sh
+
+      - name: Run exwiw (explain)
+        run: scenario/test_explain_with_postgresql.sh
 
   with_mongodb:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `skip: true` table config attribute to explicitly exclude a table from the dump. Skipped tables produce no schema entry, no `insert-*` file, and no `delete-*` file. Using a skipped table as `--target-table`, or having another non-skipped table reference it via `belongs_to`, raises `ArgumentError` on load. Available for both SQL adapters (`TableConfig`) and the MongoDB adapter (`MongodbCollectionConfig`).
+- `dump` / `explain` subcommands. `dump` is the default and preserves the existing behavior when no subcommand is given. `explain` prints the compiled SQL and its `EXPLAIN` output (estimate-only — `EXPLAIN QUERY PLAN` on SQLite) for each extraction query to stdout without executing the SELECTs. Supported for `mysql2`, `postgresql`, and `sqlite3`; `mongodb` is not yet supported.
 
 ## [0.2.0] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ gem install exwiw
 
 ## Usage
 
+### Subcommands
+
+- `dump` (default) — generate INSERT/COPY SQL files. This is the existing behavior; if the subcommand is omitted, `dump` is assumed for backwards compatibility.
+- `explain` — print the compiled SQL and its `EXPLAIN` output (estimate-only; `EXPLAIN QUERY PLAN` on SQLite) for each query that `dump` would run, to stdout. No SELECT is executed. Supported for `mysql2`, `postgresql`, and `sqlite3`. The `mongodb` adapter is not yet supported.
+
+```bash
+# preview the queries exwiw would run, without executing the SELECTs
+exwiw explain \
+  --adapter=postgresql \
+  --host=localhost --port=5432 --user=reader \
+  --database=app_production \
+  --config-dir=exwiw \
+  --target-table=shops --ids=1
+```
+
+The `--output-dir`, `--output-format`, `--insert-only`, and `--after-insert-hook` options are dump-specific and rejected when used with `explain`.
+
 ### Command
 
 ```bash

--- a/lib/exwiw.rb
+++ b/lib/exwiw.rb
@@ -23,6 +23,7 @@ require_relative "exwiw/query_ast"
 require_relative "exwiw/query_ast_builder"
 require_relative "exwiw/after_insert_hook"
 require_relative "exwiw/runner"
+require_relative "exwiw/explain_runner"
 require_relative "exwiw/schema_generator"
 
 begin

--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -74,6 +74,13 @@ module Exwiw
       def to_copy_from_stdin(_results, _table)
         raise NotImplementedError, "COPY format is not supported by #{self.class.name}"
       end
+
+      # Run the database-specific EXPLAIN for the given query and return the
+      # output as a single string for `explain` subcommand to print.
+      # SQL adapters override; MongodbAdapter currently raises.
+      def explain(_query_ast)
+        raise NotImplementedError, "#{self.class.name} does not implement #explain"
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mongodb_adapter.rb
+++ b/lib/exwiw/adapter/mongodb_adapter.rb
@@ -97,6 +97,10 @@ module Exwiw
         raise NotImplementedError, "MongodbAdapter does not support bulk delete"
       end
 
+      def explain(_query)
+        raise NotImplementedError, "MongodbAdapter does not support explain yet"
+      end
+
       def output_extension
         'jsonl'
       end

--- a/lib/exwiw/adapter/mysql2_adapter.rb
+++ b/lib/exwiw/adapter/mysql2_adapter.rb
@@ -14,6 +14,17 @@ module Exwiw
         connection.query(sql, cast: false, as: :array).to_a
       end
 
+      def explain(query_ast)
+        sql = compile_ast(query_ast)
+
+        @logger.debug("  Executing EXPLAIN: \n#{sql}")
+        rows = connection.query("EXPLAIN #{sql}", cast: false).to_a
+        rows.each_with_index.flat_map do |row, i|
+          ["*************************** #{i + 1}. row ***************************"] +
+            row.map { |k, v| "#{k}: #{v}" }
+        end.join("\n")
+      end
+
       def dump_schema(ordered_tables, output_path)
         require 'open3'
 

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -14,6 +14,13 @@ module Exwiw
         connection.exec(sql).values
       end
 
+      def explain(query_ast)
+        sql = compile_ast(query_ast)
+
+        @logger.debug("  Executing EXPLAIN: \n#{sql}")
+        connection.exec("EXPLAIN #{sql}").values.map(&:first).join("\n")
+      end
+
       def dump_schema(ordered_tables, output_path)
         require 'open3'
 

--- a/lib/exwiw/adapter/sqlite3_adapter.rb
+++ b/lib/exwiw/adapter/sqlite3_adapter.rb
@@ -14,6 +14,14 @@ module Exwiw
         connection.execute(sql)
       end
 
+      def explain(query_ast)
+        sql = compile_ast(query_ast)
+
+        @logger.debug("  Executing EXPLAIN QUERY PLAN: \n#{sql}")
+        rows = connection.execute("EXPLAIN QUERY PLAN #{sql}")
+        rows.map { |row| row[3] }.join("\n")
+      end
+
       def dump_schema(ordered_tables, output_path)
         @logger.debug("  Reading schema from sqlite_master...")
         target_names = ordered_tables.map(&:name)

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -10,26 +10,36 @@ require 'exwiw'
 
 module Exwiw
   class CLI
+    KNOWN_SUBCOMMANDS = %w[dump explain].freeze
+
     def self.start(argv)
       new(argv).run
     end
 
     def initialize(argv)
       @argv = argv.dup
-      @help = argv.empty?
+
+      @subcommand =
+        if !@argv.empty? && !@argv.first.start_with?("-") && KNOWN_SUBCOMMANDS.include?(@argv.first)
+          @argv.shift
+        else
+          "dump"
+        end
+
+      @help = @argv.empty?
 
       @database_host = nil
       @database_port = nil
       @database_user = nil
       @database_password = ENV["DATABASE_PASSWORD"]
-      @output_dir = "dump"
+      @output_dir = nil
       @config_dir = nil
       @database_adapter = nil
       @database_name = nil
       @target_table_name = nil
       @ids = []
-      @output_format = 'insert'
-      @insert_only = false
+      @output_format = nil
+      @insert_only = nil
       @after_insert_hook_path = nil
       @log_level = :info
 
@@ -39,25 +49,29 @@ module Exwiw
     def run
       if @help
         puts parser.help
-      else
-        validate_options!
+        return
+      end
 
-        connection_config = ConnectionConfig.new(
-          adapter: @database_adapter,
-          host: @database_host,
-          port: @database_port,
-          user: @database_user,
-          password: @database_password,
-          database_name: @database_name,
-        )
+      validate_options!
 
-        dump_target = DumpTarget.new(
-          table_name: @target_table_name,
-          ids: @ids,
-        )
+      connection_config = ConnectionConfig.new(
+        adapter: @database_adapter,
+        host: @database_host,
+        port: @database_port,
+        user: @database_user,
+        password: @database_password,
+        database_name: @database_name,
+      )
 
-        logger = build_logger
+      dump_target = DumpTarget.new(
+        table_name: @target_table_name,
+        ids: @ids,
+      )
 
+      logger = build_logger
+
+      case @subcommand
+      when "dump"
         Runner.new(
           connection_config: connection_config,
           output_dir: @output_dir,
@@ -69,10 +83,22 @@ module Exwiw
           cli_options: build_cli_options_hash,
           logger: logger,
         ).run
+      when "explain"
+        ExplainRunner.new(
+          connection_config: connection_config,
+          config_dir: @config_dir,
+          dump_target: dump_target,
+          logger: logger,
+          io: $stdout,
+        ).run
       end
     end
 
     private def validate_options!
+      if @subcommand == "explain"
+        validate_explain_only!
+      end
+
       if @database_adapter != "sqlite3"
         required_options = {
           "Target database host" => @database_host,
@@ -99,15 +125,21 @@ module Exwiw
         exit 1
       end
 
-      valid_output_formats = ["insert", "copy"]
-      unless valid_output_formats.include?(@output_format)
-        $stderr.puts "Invalid output format '#{@output_format}'. Available options are: #{valid_output_formats.join(', ')}"
-        exit 1
-      end
+      if @subcommand == "dump"
+        @output_dir ||= "dump"
+        @output_format ||= "insert"
+        @insert_only = @insert_only ? true : false
 
-      if @output_format == "copy" && @database_adapter != "postgresql"
-        $stderr.puts "--output-format=copy is only supported with the postgresql adapter"
-        exit 1
+        valid_output_formats = ["insert", "copy"]
+        unless valid_output_formats.include?(@output_format)
+          $stderr.puts "Invalid output format '#{@output_format}'. Available options are: #{valid_output_formats.join(', ')}"
+          exit 1
+        end
+
+        if @output_format == "copy" && @database_adapter != "postgresql"
+          $stderr.puts "--output-format=copy is only supported with the postgresql adapter"
+          exit 1
+        end
       end
 
       if @config_dir.nil?
@@ -149,6 +181,24 @@ module Exwiw
       end
     end
 
+    private def validate_explain_only!
+      if @database_adapter == "mongodb"
+        $stderr.puts "mongodb adapter is not yet supported by 'explain' subcommand"
+        exit 1
+      end
+
+      rejected = []
+      rejected << "--output-dir" unless @output_dir.nil?
+      rejected << "--output-format" unless @output_format.nil?
+      rejected << "--insert-only" unless @insert_only.nil?
+      rejected << "--after-insert-hook" unless @after_insert_hook_path.nil?
+
+      unless rejected.empty?
+        $stderr.puts "The following options are not applicable in 'explain' subcommand: #{rejected.join(', ')}"
+        exit 1
+      end
+    end
+
     private def build_cli_options_hash
       {
         database_host: @database_host,
@@ -185,13 +235,22 @@ module Exwiw
 
     private def parser
       @parser ||= OptionParser.new do |opts|
-        opts.banner = "exwiw #{Exwiw::VERSION}"
+        opts.banner = <<~BANNER
+          exwiw #{Exwiw::VERSION}
+
+          Usage: exwiw [SUBCOMMAND] [options]
+
+          Subcommands:
+            dump      Generate INSERT/COPY SQL files (default when omitted).
+            explain   Print EXPLAIN output for each extraction query to stdout.
+                      (not yet supported for the mongodb adapter)
+        BANNER
         opts.version = Exwiw::VERSION
 
         opts.on("-h", "--host=HOST", "Target database host") { |v| @database_host = v }
         opts.on("-p", "--port=PORT", "Target database port") { |v| @database_port = v }
         opts.on("-u", "--user=USERNAME", "Target database user") { |v| @database_user = v }
-        opts.on("-o", "--output-dir=[DUMP_DIR_PATH]", "Output file path. default is dump/") do |v|
+        opts.on("-o", "--output-dir=[DUMP_DIR_PATH]", "Output file path. default is dump/ (dump subcommand only)") do |v|
           v = v.end_with?("/") ? v[0..-2] : v
           @output_dir = File.expand_path(v)
         end
@@ -203,9 +262,9 @@ module Exwiw
         opts.on("--database=DATABASE", "Target database name") { |v| @database_name = v }
         opts.on("--target-table=[TABLE]", "Target table for extraction. If omitted, dump all tables.") { |v| @target_table_name = v }
         opts.on("--ids=[IDS]", "Comma-separated list of identifiers. Required when --target-table is given.") { |v| @ids = v.split(',') }
-        opts.on("--output-format=[FORMAT]", "Output format: insert (default) or copy (PostgreSQL only)") { |v| @output_format = v }
-        opts.on("--insert-only", "Do not generate DELETE SQL files") { @insert_only = true }
-        opts.on("--after-insert-hook=PATH", "Path to a .rb or .sh post-processing hook executed after all insert/delete files are written") do |v|
+        opts.on("--output-format=[FORMAT]", "Output format: insert (default) or copy (PostgreSQL only, dump subcommand only)") { |v| @output_format = v }
+        opts.on("--insert-only", "Do not generate DELETE SQL files (dump subcommand only)") { @insert_only = true }
+        opts.on("--after-insert-hook=PATH", "Path to a .rb or .sh post-processing hook executed after all insert/delete files are written (dump subcommand only)") do |v|
           @after_insert_hook_path = File.expand_path(v)
         end
         opts.on("--log-level=LEVEL", "Log level (debug, info). default is info") { |v| @log_level = v.to_sym }

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Exwiw
+  class ExplainRunner
+    def initialize(
+      connection_config:,
+      config_dir:,
+      dump_target:,
+      logger:,
+      io: $stdout
+    )
+      @connection_config = connection_config
+      @config_dir = config_dir
+      @dump_target = dump_target
+      @logger = logger
+      @io = io
+    end
+
+    def run
+      adapter = Adapter.build(@connection_config, @logger)
+      configs = load_table_config(adapter.class.table_config_class)
+      configs = reject_and_validate_skipped(configs)
+
+      table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
+
+      target = table_by_name[@dump_target.table_name]
+      adapter.validate_as_dump_target!(target) if target
+
+      @logger.debug("Determining table processing order...")
+      ordered_table_names = DetermineTableProcessingOrder.run(configs.select { |c| adapter.dumpable?(c) })
+
+      total_size = ordered_table_names.size
+      ordered_table_names.each_with_index do |table_name, idx|
+        @logger.debug("Explaining '#{table_name}'... (#{idx + 1}/#{total_size})")
+        table = table_by_name.fetch(table_name)
+
+        query_ast = adapter.build_query(table, @dump_target, table_by_name)
+        sql = adapter.compile_ast(query_ast)
+        explain_text = adapter.explain(query_ast)
+
+        @io.puts "-- [#{idx + 1}/#{total_size}] #{table_name}"
+        @io.puts sql
+        @io.puts
+        @io.puts "-- EXPLAIN:"
+        @io.puts explain_text
+        @io.puts
+      end
+    end
+
+    private def load_table_config(klass)
+      Dir[File.join(@config_dir, "*.json")].map do |file|
+        json = JSON.parse(File.read(file))
+        klass.from(json)
+      end
+    end
+
+    private def reject_and_validate_skipped(configs)
+      skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
+      return configs if skipped_names.empty?
+
+      configs.each do |config|
+        next if config.skip
+        next unless config.respond_to?(:belongs_tos)
+
+        dangling = config.belongs_tos.select { |rel| skipped_names.include?(rel.table_name) }
+        next if dangling.empty?
+
+        raise ArgumentError,
+              "Table '#{config.name}' has belongs_to references to skipped table(s): " \
+              "#{dangling.map(&:table_name).join(', ')}. " \
+              "Remove the belongs_to entries or unset `skip` on the referenced table."
+      end
+
+      if @dump_target.table_name && skipped_names.include?(@dump_target.table_name)
+        raise ArgumentError,
+              "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
+      end
+
+      skipped_names.each { |n| @logger.info("Skipping table '#{n}' (skip:true)") }
+      configs.reject { |c| c.skip }
+    end
+  end
+end

--- a/scenario/test_explain_with_mysql2.sh
+++ b/scenario/test_explain_with_mysql2.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export FROM_DATABASE_NAME="exwiw_scenario_explain_db"
+EXPLAIN_OUT="tmp/mysql2-explain.out"
+
+# Determine MySQL command based on environment
+if [ -n "$CI" ]; then
+  MYSQL_CMD="mysql -h 127.0.0.1 -P 3306 -u root -prootpassword"
+else
+  MYSQL_CMD="docker compose exec -T -e MYSQL_PWD=rootpassword mysql mysql -u root"
+fi
+
+# Clean up
+mkdir -p tmp
+rm -f "$EXPLAIN_OUT" tmp/mysql2-explain.err
+$MYSQL_CMD -e "DROP DATABASE IF EXISTS ${FROM_DATABASE_NAME}; CREATE DATABASE ${FROM_DATABASE_NAME};"
+
+# Setup db
+$MYSQL_CMD "${FROM_DATABASE_NAME}" < seed/mysql2-dump.sql
+
+# Snapshot tmp/ contents before running, so we can detect any unintended file
+# creation by `exwiw explain`.
+tmp_before=$(ls -1 tmp 2>/dev/null | sort)
+
+# Run `exwiw explain` and tee output to a file for later assertions while
+# keeping stdout visible in CI logs.
+export DATABASE_PASSWORD="rootpassword"
+bundle exec exe/exwiw explain \
+  --adapter=mysql2 \
+  --host=127.0.0.1 \
+  --port=3306 \
+  --user=root \
+  --database="${FROM_DATABASE_NAME}" \
+  --config-dir=scenario/mysql2-schema \
+  --target-table=shops \
+  --ids=1 \
+  | tee "$EXPLAIN_OUT"
+
+# Structural markers — one block per dumped table.
+grep -q '^-- \[1/7\] shops$'              "$EXPLAIN_OUT" || { echo "✗ missing shops header";        exit 1; }
+grep -q '^-- \[7/7\] transactions$'       "$EXPLAIN_OUT" || { echo "✗ missing transactions header"; exit 1; }
+grep -q '^-- EXPLAIN:$'                   "$EXPLAIN_OUT" || { echo "✗ missing EXPLAIN marker";      exit 1; }
+
+# Compiled SELECT for the dump_target.
+grep -q 'SELECT shops.id'                 "$EXPLAIN_OUT" || { echo "✗ missing compiled SELECT for shops"; exit 1; }
+grep -q "FROM shops WHERE shops.id = '1'" "$EXPLAIN_OUT" || { echo "✗ missing WHERE clause for shops"; exit 1; }
+
+# MySQL-specific: we format EXPLAIN as vertical (\G-style) rows. The header
+# line is always emitted. MySQL 5.7/8.0 expose classic columns (table, type,
+# rows, ...) while MySQL 8.0.16+ returns a single `EXPLAIN:` column with tree
+# text — both forms include "1. row" in our output.
+grep -q '1\. row'                         "$EXPLAIN_OUT" || { echo "✗ no MySQL EXPLAIN vertical row marker"; exit 1; }
+
+# No file should have been created in tmp/ besides our captured output.
+tmp_after=$(ls -1 tmp | sort)
+expected=$(printf '%s\n%s\n' "$tmp_before" "$(basename "$EXPLAIN_OUT")" | sort -u | grep -v '^$')
+if [ "$tmp_after" != "$expected" ]; then
+  echo "✗ explain created unexpected files in tmp/:"
+  diff <(echo "$expected") <(echo "$tmp_after") || true
+  exit 1
+fi
+
+echo "✓ mysql2 explain produced expected output and wrote no extra files"
+
+# Rejection case: dump-only flag must be refused.
+echo "Testing explain rejection of --insert-only..."
+set +e
+bundle exec exe/exwiw explain \
+    --adapter=mysql2 \
+    --host=127.0.0.1 \
+    --port=3306 \
+    --user=root \
+    --database="${FROM_DATABASE_NAME}" \
+    --config-dir=scenario/mysql2-schema \
+    --insert-only \
+    2>&1 | tee tmp/mysql2-explain.err
+rejection_exit=${PIPESTATUS[0]}
+set -e
+if [ "$rejection_exit" -eq 0 ]; then
+  echo "✗ explain should have rejected --insert-only (exit 0)"
+  exit 1
+fi
+grep -q "not applicable in 'explain'" tmp/mysql2-explain.err || {
+  echo "✗ unexpected rejection message:"
+  cat tmp/mysql2-explain.err
+  exit 1
+}
+echo "✓ mysql2 explain rejects --insert-only with the expected message"

--- a/scenario/test_explain_with_postgresql.sh
+++ b/scenario/test_explain_with_postgresql.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export FROM_DATABASE_NAME="exwiw_scenario_explain_db"
+EXPLAIN_OUT="tmp/postgresql-explain.out"
+
+# Determine PostgreSQL command based on environment
+if [ -n "$CI" ]; then
+  export PGPASSWORD="test_password"
+  PSQL_CMD="psql -h 127.0.0.1 -p 5432 -U postgres"
+  PSQL_FILE_CMD="psql -h 127.0.0.1 -p 5432 -U postgres"
+else
+  PSQL_CMD="docker compose exec postgres psql -U postgres"
+  PSQL_FILE_CMD="docker compose exec postgres psql -U postgres"
+fi
+
+# Clean up
+mkdir -p tmp
+rm -f "$EXPLAIN_OUT" tmp/postgresql-explain.err
+$PSQL_CMD -c "DROP DATABASE IF EXISTS ${FROM_DATABASE_NAME}" > /dev/null
+$PSQL_CMD -c "CREATE DATABASE ${FROM_DATABASE_NAME}" > /dev/null
+
+# Setup db
+if [ -n "$CI" ]; then
+  $PSQL_FILE_CMD -d "${FROM_DATABASE_NAME}" -f seed/postgresql-dump.sql > /dev/null
+else
+  docker compose exec postgres psql -U postgres -d "${FROM_DATABASE_NAME}" -f /seed/postgresql-dump.sql > /dev/null
+fi
+
+# Snapshot tmp/ contents before running, so we can detect any unintended file
+# creation by `exwiw explain`.
+tmp_before=$(ls -1 tmp 2>/dev/null | sort)
+
+# Run `exwiw explain` and tee output to a file for later assertions while
+# keeping stdout visible in CI logs.
+export DATABASE_PASSWORD="test_password"
+bundle exec exe/exwiw explain \
+  --adapter=postgresql \
+  --host=127.0.0.1 \
+  --port=5432 \
+  --user=postgres \
+  --database="${FROM_DATABASE_NAME}" \
+  --config-dir=scenario/postgresql-schema \
+  --target-table=shops \
+  --ids=1 \
+  | tee "$EXPLAIN_OUT"
+
+# Structural markers — one block per dumped table.
+grep -q '^-- \[1/7\] shops$'              "$EXPLAIN_OUT" || { echo "✗ missing shops header";        exit 1; }
+grep -q '^-- \[7/7\] transactions$'       "$EXPLAIN_OUT" || { echo "✗ missing transactions header"; exit 1; }
+grep -q '^-- EXPLAIN:$'                   "$EXPLAIN_OUT" || { echo "✗ missing EXPLAIN marker";      exit 1; }
+
+# Compiled SELECT for the dump_target.
+grep -q 'SELECT shops.id'                 "$EXPLAIN_OUT" || { echo "✗ missing compiled SELECT for shops"; exit 1; }
+grep -q "FROM shops WHERE shops.id = '1'" "$EXPLAIN_OUT" || { echo "✗ missing WHERE clause for shops"; exit 1; }
+
+# PostgreSQL-specific: EXPLAIN emits node names with cost annotations like
+# "Seq Scan on shops  (cost=0.00..1.06 rows=1 width=56)". Loose match.
+grep -Eq '(Scan|Index|Join) .*\(cost='    "$EXPLAIN_OUT" || { echo "✗ no PG EXPLAIN cost line found"; exit 1; }
+
+# No file should have been created in tmp/ besides our captured output.
+tmp_after=$(ls -1 tmp | sort)
+expected=$(printf '%s\n%s\n' "$tmp_before" "$(basename "$EXPLAIN_OUT")" | sort -u | grep -v '^$')
+if [ "$tmp_after" != "$expected" ]; then
+  echo "✗ explain created unexpected files in tmp/:"
+  diff <(echo "$expected") <(echo "$tmp_after") || true
+  exit 1
+fi
+
+echo "✓ postgresql explain produced expected output and wrote no extra files"
+
+# Rejection case: dump-only flag must be refused.
+echo "Testing explain rejection of --output-format..."
+set +e
+bundle exec exe/exwiw explain \
+    --adapter=postgresql \
+    --host=127.0.0.1 \
+    --port=5432 \
+    --user=postgres \
+    --database="${FROM_DATABASE_NAME}" \
+    --config-dir=scenario/postgresql-schema \
+    --output-format=copy \
+    2>&1 | tee tmp/postgresql-explain.err
+rejection_exit=${PIPESTATUS[0]}
+set -e
+if [ "$rejection_exit" -eq 0 ]; then
+  echo "✗ explain should have rejected --output-format=copy (exit 0)"
+  exit 1
+fi
+grep -q "not applicable in 'explain'" tmp/postgresql-explain.err || {
+  echo "✗ unexpected rejection message:"
+  cat tmp/postgresql-explain.err
+  exit 1
+}
+echo "✓ postgresql explain rejects --output-format with the expected message"

--- a/scenario/test_explain_with_sqlite3.sh
+++ b/scenario/test_explain_with_sqlite3.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -eo pipefail
+
+TARGET_DB_PATH="tmp/scenario-explain-target.sqlite3"
+EXPLAIN_OUT="tmp/sqlite3-explain.out"
+
+# Clean up
+rm -f "$TARGET_DB_PATH" "$EXPLAIN_OUT"
+mkdir -p tmp
+
+# Setup db
+cp scenario/initdb/init.sqlite3 "$TARGET_DB_PATH"
+
+# Snapshot the current `tmp/` listing so we can detect any unintended file
+# creation by `exwiw explain` (it should write only to stdout, never to disk).
+tmp_before=$(ls -1 tmp 2>/dev/null | sort)
+
+# Run `exwiw explain` and capture stdout. stderr (the logger) is allowed
+# through unchanged so CI users can read the progress lines on failure.
+bundle exec exe/exwiw explain \
+  --adapter=sqlite3 \
+  --database="${TARGET_DB_PATH}" \
+  --config-dir=scenario/sqlite3-schema \
+  --target-table=shops \
+  --ids=1 \
+  | tee "$EXPLAIN_OUT"
+
+# Structural markers — one block per dumped table.
+grep -q '^-- \[1/7\] shops$'             "$EXPLAIN_OUT" || { echo "✗ missing shops header";        exit 1; }
+grep -q '^-- \[7/7\] transactions$'      "$EXPLAIN_OUT" || { echo "✗ missing transactions header"; exit 1; }
+grep -q '^-- EXPLAIN:$'                  "$EXPLAIN_OUT" || { echo "✗ missing EXPLAIN marker";      exit 1; }
+
+# The compiled SELECT for the dump_target must appear verbatim.
+grep -q 'SELECT shops.id'                "$EXPLAIN_OUT" || { echo "✗ missing compiled SELECT for shops"; exit 1; }
+grep -q "FROM shops WHERE shops.id = '1'" "$EXPLAIN_OUT" || { echo "✗ missing WHERE clause for shops"; exit 1; }
+
+# SQLite-specific: `EXPLAIN QUERY PLAN` emits SEARCH/SCAN nodes.
+grep -Eq '^(SEARCH|SCAN) '               "$EXPLAIN_OUT" || { echo "✗ no EXPLAIN QUERY PLAN node found"; exit 1; }
+
+# No file should have been created in tmp/ besides the target DB and our
+# captured output. In particular, no `dump/` directory should be created.
+tmp_after=$(ls -1 tmp | sort)
+expected=$(printf '%s\n%s\n%s\n' "$tmp_before" "$(basename "$TARGET_DB_PATH")" "$(basename "$EXPLAIN_OUT")" | sort -u | grep -v '^$')
+if [ "$tmp_after" != "$expected" ]; then
+  echo "✗ explain created unexpected files in tmp/:"
+  diff <(echo "$expected") <(echo "$tmp_after") || true
+  exit 1
+fi
+
+echo "✓ sqlite3 explain produced expected output and wrote no extra files"
+
+# Rejection case: dump-only flag must be refused.
+# `tee` lets CI logs surface the rejection message; `|| true` lets us treat the
+# expected non-zero exit as success in the surrounding `set -e` script.
+echo "Testing explain rejection of --output-format..."
+set +e
+bundle exec exe/exwiw explain \
+    --adapter=sqlite3 \
+    --database="${TARGET_DB_PATH}" \
+    --config-dir=scenario/sqlite3-schema \
+    --output-format=copy \
+    2>&1 | tee tmp/sqlite3-explain.err
+rejection_exit=${PIPESTATUS[0]}
+set -e
+if [ "$rejection_exit" -eq 0 ]; then
+  echo "✗ explain should have rejected --output-format=copy (exit 0)"
+  exit 1
+fi
+grep -q "not applicable in 'explain'" tmp/sqlite3-explain.err || {
+  echo "✗ unexpected rejection message:"
+  cat tmp/sqlite3-explain.err
+  exit 1
+}
+echo "✓ sqlite3 explain rejects --output-format with the expected message"

--- a/spec/adapter/mysql2_adapter_spec.rb
+++ b/spec/adapter/mysql2_adapter_spec.rb
@@ -198,6 +198,20 @@ module Exwiw
         end
       end
 
+      describe "#explain" do
+        it "returns EXPLAIN output for a simple select" do
+          output = adapter.explain(build_select_shops_ast)
+          expect(output).to be_a(String)
+          expect(output).not_to be_empty
+          # Output is formatted as vertical rows; assert that header markers and
+          # at least one key/value pair are present. MySQL 5.7/8.0 return classic
+          # table columns (id/select_type/table/...); MySQL 8.0.16+ returns a
+          # single EXPLAIN column with tree-format text. Both are acceptable.
+          expect(output).to include('1. row')
+          expect(output).to match(/(table|EXPLAIN):/i)
+        end
+      end
+
       describe "#to_bulk_insert" do
         let(:bulk_insert_sql) { adapter.to_bulk_insert(results, shops_table(adapter_name)) }
 

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -209,6 +209,16 @@ module Exwiw
         end
       end
 
+      describe "#explain" do
+        it "returns EXPLAIN output for a simple select" do
+          output = adapter.explain(build_select_shops_ast)
+          expect(output).to be_a(String)
+          expect(output).not_to be_empty
+          # postgres EXPLAIN includes scan-node descriptions
+          expect(output).to match(/Scan|shops/i)
+        end
+      end
+
       describe "#to_bulk_insert" do
         let(:bulk_insert_sql) { adapter.to_bulk_insert(results, shops_table(adapter_name)) }
 

--- a/spec/adapter/sqlite3_adapter_spec.rb
+++ b/spec/adapter/sqlite3_adapter_spec.rb
@@ -220,6 +220,22 @@ module Exwiw
         end
       end
 
+      describe "#explain" do
+        it "returns EXPLAIN QUERY PLAN output for a simple select" do
+          output = adapter.explain(build_select_shops_ast)
+          expect(output).to be_a(String)
+          expect(output).not_to be_empty
+          expect(output).to match(/shops/i)
+        end
+
+        it "returns EXPLAIN QUERY PLAN output for a join query" do
+          output = adapter.explain(build_order_items_ast)
+          expect(output).to be_a(String)
+          expect(output).not_to be_empty
+          expect(output).to match(/order_items|orders/i)
+        end
+      end
+
       describe "#to_bulk_insert" do
         let(:bulk_insert_sql) { adapter.to_bulk_insert(results, shops_table(adapter_name)) }
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'exwiw/cli'
+
+module Exwiw
+  RSpec.describe CLI do
+    describe 'subcommand parsing' do
+      it 'defaults to "dump" when no subcommand is given' do
+        cli = CLI.new(['--adapter=sqlite3', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite3-schema'])
+        expect(cli.instance_variable_get(:@subcommand)).to eq('dump')
+      end
+
+      it 'recognizes "dump" as a subcommand' do
+        cli = CLI.new(['dump', '--adapter=sqlite3', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite3-schema'])
+        expect(cli.instance_variable_get(:@subcommand)).to eq('dump')
+      end
+
+      it 'recognizes "explain" as a subcommand' do
+        cli = CLI.new(['explain', '--adapter=sqlite3', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite3-schema'])
+        expect(cli.instance_variable_get(:@subcommand)).to eq('explain')
+      end
+
+      it 'does not treat an option-looking argv[0] as a subcommand' do
+        cli = CLI.new(['--adapter=sqlite3', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite3-schema'])
+        expect(cli.instance_variable_get(:@subcommand)).to eq('dump')
+      end
+
+      it 'does not consume unknown positional arguments as a subcommand' do
+        cli = CLI.new(['foo', '--adapter=sqlite3', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite3-schema'])
+        expect(cli.instance_variable_get(:@subcommand)).to eq('dump')
+      end
+    end
+
+    describe 'explain subcommand validation' do
+      def run_cli(argv)
+        CLI.new(argv).run
+      end
+
+      it 'rejects --output-format with explain' do
+        argv = ['explain', '--adapter=sqlite3', '--database=tmp/test.sqlite3',
+                '--config-dir=scenario/sqlite3-schema', '--output-format=copy']
+        expect { run_cli(argv) }.to raise_error(SystemExit).and output(/not applicable in 'explain'/).to_stderr
+      end
+
+      it 'rejects --insert-only with explain' do
+        argv = ['explain', '--adapter=sqlite3', '--database=tmp/test.sqlite3',
+                '--config-dir=scenario/sqlite3-schema', '--insert-only']
+        expect { run_cli(argv) }.to raise_error(SystemExit).and output(/not applicable in 'explain'/).to_stderr
+      end
+
+      it 'rejects --output-dir with explain' do
+        argv = ['explain', '--adapter=sqlite3', '--database=tmp/test.sqlite3',
+                '--config-dir=scenario/sqlite3-schema', '--output-dir=tmp/x']
+        expect { run_cli(argv) }.to raise_error(SystemExit).and output(/not applicable in 'explain'/).to_stderr
+      end
+
+      it 'rejects --after-insert-hook with explain' do
+        argv = ['explain', '--adapter=sqlite3', '--database=tmp/test.sqlite3',
+                '--config-dir=scenario/sqlite3-schema', '--after-insert-hook=/tmp/some.rb']
+        expect { run_cli(argv) }.to raise_error(SystemExit).and output(/not applicable in 'explain'/).to_stderr
+      end
+
+      it 'rejects mongodb adapter with explain' do
+        argv = ['explain', '--adapter=mongodb', '--host=localhost', '--port=27017',
+                '--database=app', '--config-dir=scenario/mongodb-schema']
+        expect { run_cli(argv) }.to raise_error(SystemExit).and output(/mongodb adapter is not yet supported by 'explain'/).to_stderr
+      end
+    end
+  end
+end

--- a/spec/explain_runner_spec.rb
+++ b/spec/explain_runner_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'stringio'
+require 'tmpdir'
+
+module Exwiw
+  RSpec.describe ExplainRunner do
+    let(:connection_config) do
+      ConnectionConfig.new(
+        adapter: 'sqlite3',
+        database_name: 'tmp/test.sqlite3',
+        host: nil,
+        port: nil,
+        user: nil,
+        password: nil,
+      )
+    end
+    let(:io) { StringIO.new }
+    let(:logger) { ::Logger.new(nil) }
+    let(:config_dir) { @config_dir }
+    let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
+    let(:runner) do
+      ExplainRunner.new(
+        connection_config: connection_config,
+        config_dir: config_dir,
+        dump_target: dump_target,
+        logger: logger,
+        io: io,
+      )
+    end
+
+    around do |example|
+      Dir.mktmpdir do |config|
+        @config_dir = config
+        example.run
+      end
+    end
+
+    describe '#run with --target-table' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+      before do
+        FileUtils.cp('scenario/sqlite3-schema/shops.json', File.join(config_dir, 'shops.json'))
+      end
+
+      it 'prints compiled SQL and EXPLAIN output for the target table' do
+        runner.run
+
+        out = io.string
+        expect(out).to include('-- [1/1] shops')
+        expect(out).to include('SELECT shops.id')
+        expect(out).to include('FROM shops')
+        expect(out).to include('-- EXPLAIN:')
+      end
+
+      it 'does not write any file' do
+        Dir.mktmpdir do |dir|
+          before_files = Dir[File.join(dir, '*')]
+          runner.run
+          after_files = Dir[File.join(dir, '*')]
+          expect(after_files).to eq(before_files)
+        end
+      end
+    end
+
+    describe '#run without --target-table (dump-all mode)' do
+      let(:runner) do
+        ExplainRunner.new(
+          connection_config: connection_config,
+          config_dir: 'scenario/sqlite3-schema',
+          dump_target: dump_target,
+          logger: logger,
+          io: io,
+        )
+      end
+
+      it 'prints one block per table' do
+        runner.run
+
+        out = io.string
+        expect(out).to include('-- [1/')
+        expect(out.scan(/-- EXPLAIN:/).size).to be >= 1
+        expect(out).to include('FROM shops')
+      end
+    end
+
+    describe '#run when --target-table is marked skip:true' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+      before do
+        shops = JSON.parse(File.read('scenario/sqlite3-schema/shops.json'))
+        shops['skip'] = true
+        File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
+      end
+
+      it 'raises ArgumentError' do
+        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked skip:true/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `dump` サブコマンドをデフォルトとして、新規に `explain` サブコマンドを追加
- `explain` は各抽出クエリのコンパイル済み SQL と `EXPLAIN` 結果を標準出力に出力 (SELECT は実行しない)
- `mysql2` / `postgresql` / `sqlite3` に対応 (sqlite3 は `EXPLAIN QUERY PLAN`)、`mongodb` は今回非対応
- サブコマンド省略時は `dump` にフォールバックするので既存ユーザーへの破壊的変更なし

## Usage

\`\`\`bash
exwiw explain \\
  --adapter=postgresql --host=... --user=... --database=... \\
  --config-dir=exwiw --target-table=shops --ids=1
\`\`\`

各テーブルごとに `-- [N/M] <table>` ヘッダ → コンパイル済み SELECT → `-- EXPLAIN:` → EXPLAIN 結果、を順に stdout に出す。

`--output-dir` / `--output-format` / `--insert-only` / `--after-insert-hook` は dump 専用のため explain モードでは明示的に reject。

## Test plan

- [x] `bundle exec rspec` (全 spec 通過 — 194 examples)
- [x] `scenario/test_explain_with_sqlite3.sh` をローカルで実行
- [x] `scenario/test_explain_with_mysql2.sh` をローカルで実行
- [x] `scenario/test_explain_with_postgresql.sh` をローカルで実行
- [x] 既存 dump サブコマンド (省略時) の後方互換確認
- [ ] CI で 3 アダプターの explain scenario job が通る

## MongoDB の今後

`MongodbAdapter#build_query` が `@state[...]` (先行 collection の execute 結果) に依存するため、explain 時に SELECT を走らせずに下流の query を組み立てる手段が無い。dump_target のみを `find().explain(verbosity: 'queryPlanner')` する形に絞れば対応可能。次回別 PR で検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)