### PR TITLE
feat: skip:true テーブルでもスキーマは出力する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `skip: true` table config now still emits the table's DDL into `insert-000-schema.{sql,js}` so downstream schemas stay consistent; only data extraction (`insert-*` / `delete-*`) is skipped. Previously the table was excluded from the schema file as well.
+
 ## [0.2.1] - 2026-05-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Note: Ruby hooks are evaluated via `instance_eval` inside the exwiw process — 
 
 ### Skip a table
 
-Set `"skip": true` on a table's config JSON to explicitly exclude it from the dump. The table is omitted from `insert-000-schema.{sql,js}`, and no `insert-*` / `delete-*` files are generated for it. Skipped tables are also not queried at all.
+Set `"skip": true` on a table's config JSON to exclude it from data extraction. The table's DDL is still emitted into `insert-000-schema.{sql,js}` so the schema stays consistent, but no `insert-*` / `delete-*` files are generated for it and the table is never queried.
 
 ```json
 {

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -19,7 +19,7 @@ module Exwiw
     def run
       adapter = Adapter.build(@connection_config, @logger)
       configs = load_table_config(adapter.class.table_config_class)
-      configs = reject_and_validate_skipped(configs)
+      validate_skipped(configs)
 
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
@@ -31,8 +31,13 @@ module Exwiw
 
       total_size = ordered_table_names.size
       ordered_table_names.each_with_index do |table_name, idx|
-        @logger.debug("Explaining '#{table_name}'... (#{idx + 1}/#{total_size})")
         table = table_by_name.fetch(table_name)
+        if table.skip
+          @logger.debug("Skipping explain for '#{table_name}' (skip:true)")
+          next
+        end
+
+        @logger.debug("Explaining '#{table_name}'... (#{idx + 1}/#{total_size})")
 
         query_ast = adapter.build_query(table, @dump_target, table_by_name)
         sql = adapter.compile_ast(query_ast)
@@ -54,9 +59,9 @@ module Exwiw
       end
     end
 
-    private def reject_and_validate_skipped(configs)
+    private def validate_skipped(configs)
       skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
-      return configs if skipped_names.empty?
+      return if skipped_names.empty?
 
       configs.each do |config|
         next if config.skip
@@ -75,9 +80,6 @@ module Exwiw
         raise ArgumentError,
               "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
       end
-
-      skipped_names.each { |n| @logger.info("Skipping table '#{n}' (skip:true)") }
-      configs.reject { |c| c.skip }
     end
   end
 end

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -30,7 +30,7 @@ module Exwiw
       adapter = Adapter.build(@connection_config, @logger)
       configs = load_table_config(adapter.class.table_config_class)
 
-      configs = reject_and_validate_skipped(configs)
+      validate_skipped(configs)
 
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
@@ -51,8 +51,14 @@ module Exwiw
 
       total_size = ordered_table_names.size
       ordered_table_names.each_with_index do |table_name, idx|
-        @logger.info("Processing table '#{table_name}'... (#{idx + 1}/#{total_size})")
         table = table_by_name.fetch(table_name)
+
+        if table.skip
+          @logger.info("Skipping data extraction for '#{table_name}' (skip:true)")
+          next
+        end
+
+        @logger.info("Processing table '#{table_name}'... (#{idx + 1}/#{total_size})")
 
         query_ast = adapter.build_query(table, @dump_target, table_by_name)
         results = adapter.execute(query_ast)
@@ -123,9 +129,9 @@ module Exwiw
       end
     end
 
-    private def reject_and_validate_skipped(configs)
+    private def validate_skipped(configs)
       skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
-      return configs if skipped_names.empty?
+      return if skipped_names.empty?
 
       configs.each do |config|
         next if config.skip
@@ -145,8 +151,7 @@ module Exwiw
               "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
       end
 
-      skipped_names.each { |n| @logger.info("Skipping table '#{n}' (skip:true)") }
-      configs.reject { |c| c.skip }
+      skipped_names.each { |n| @logger.info("Table '#{n}' is marked skip:true (schema will be included, data extraction skipped)") }
     end
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -186,7 +186,7 @@ module Exwiw
         File.write(File.join(config_dir, 'system_announcements.json'), JSON.dump(announcements))
       end
 
-      it 'does not emit schema, insert, or delete files for the skipped table' do
+      it 'emits schema for the skipped table but no insert/delete files' do
         runner.run
 
         expect(Dir[File.join(output_dir, 'insert-*-system_announcements.sql')]).to be_empty
@@ -194,7 +194,7 @@ module Exwiw
 
         schema_file = File.join(output_dir, 'insert-000-schema.sql')
         expect(File.exist?(schema_file)).to be(true)
-        expect(File.read(schema_file)).not_to include('system_announcements')
+        expect(File.read(schema_file)).to include('system_announcements')
       end
 
       it 'still emits files for non-skipped tables' do


### PR DESCRIPTION
## Summary

PR #26 で導入された `skip:true` は insert-000-schema にも出力されず、DDL ごとターゲット DB から落ちていた。データ抽出のみ抑止して DDL は維持したいユースケース（schema を揃えたいがデータは要らないテーブル）に対応するため、skip 対象もスキーマ出力には含めるよう変更する。

- `runner.rb` / `explain_runner.rb`: configs から skip テーブルを reject せず、反復ループ内で skip 判定して `insert-*` / `delete-*` 生成（および explain）のみスキップ
- `reject_and_validate_skipped` → `validate_skipped` に責務を validation のみへ縮小
- `belongs_to` から skip テーブルへの参照禁止、および `--target-table` への skip テーブル指定禁止という既存制約は維持
- 既存テストを「schema には含まれる」期待に更新
- README / CHANGELOG (Unreleased) を追記

## Test plan

- [x] `bundle exec rake spec` — 194 examples, 0 failures
- [ ] skip:true なテーブルを混ぜたコンフィグでダンプし、`insert-000-schema.sql` に当該テーブルの `CREATE TABLE` が含まれること
- [ ] 同シナリオで `insert-*-<skipped>.sql` / `delete-*-<skipped>.sql` が生成されないこと
- [ ] 他テーブルが belongs_to で skip テーブルを参照しているとき ArgumentError になること（既存挙動）
- [ ] `--target-table` に skip テーブルを指定したとき ArgumentError になること（既存挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)