### PR TITLE
dump時に本番DBへ投げるクエリへ識別用コメントを付与

### DIFF
--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -81,6 +81,34 @@ module Exwiw
       def explain(_query_ast)
         raise NotImplementedError, "#{self.class.name} does not implement #explain"
       end
+
+      # Identifier text prepended to every query exwiw sends to the (often
+      # production) source DB, so the statement is recognizable in the
+      # processlist / slow-query log / db.currentOp() and can be killed if it
+      # runs long. e.g. "exwiw table=shops". `label` is "table=..." /
+      # "collection=...". The version is intentionally omitted to keep the
+      # comment stable across releases (snapshots / diffs). Strips `*/` to
+      # avoid breaking out of the comment.
+      def query_comment_text(label = nil)
+        parts = ["exwiw"]
+        parts << label if label
+        parts.join(' ').gsub('*/', '')
+      end
+
+      # SQL block-comment form, prefixed to SELECT / EXPLAIN.
+      def sql_query_comment(query_ast)
+        label =
+          if query_ast.respond_to?(:from_table_name) && query_ast.from_table_name
+            "table=#{query_ast.from_table_name}"
+          end
+        "/* #{query_comment_text(label)} */"
+      end
+
+      # Comment-prefixed SELECT. Relies on the SQL adapter's #compile_ast
+      # (dispatched to the subclass at runtime).
+      def commented_sql(query_ast)
+        "#{sql_query_comment(query_ast)} #{compile_ast(query_ast)}"
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mongodb_adapter.rb
+++ b/lib/exwiw/adapter/mongodb_adapter.rb
@@ -73,7 +73,11 @@ module Exwiw
       def execute(query)
         @logger.debug("  Executing Mongo find on '#{query.collection}': filter=#{query.filter.inspect} projection=#{query.projection.inspect}")
 
-        docs = db[query.collection].find(query.filter).projection(query.projection).to_a
+        docs = db[query.collection]
+          .find(query.filter)
+          .projection(query.projection)
+          .comment(query_comment_text("collection=#{query.collection}"))
+          .to_a
 
         @state[query.collection] = docs.map { |doc| doc[query.primary_key] }
 

--- a/lib/exwiw/adapter/mysql2_adapter.rb
+++ b/lib/exwiw/adapter/mysql2_adapter.rb
@@ -8,14 +8,14 @@ module Exwiw
       end
 
       def execute(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing SQL: \n#{sql}")
         connection.query(sql, cast: false, as: :array).to_a
       end
 
       def explain(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing EXPLAIN: \n#{sql}")
         rows = connection.query("EXPLAIN #{sql}", cast: false).to_a

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -8,14 +8,14 @@ module Exwiw
       end
 
       def execute(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing SQL: \n#{sql}")
         connection.exec(sql).values
       end
 
       def explain(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing EXPLAIN: \n#{sql}")
         connection.exec("EXPLAIN #{sql}").values.map(&:first).join("\n")

--- a/lib/exwiw/adapter/sqlite3_adapter.rb
+++ b/lib/exwiw/adapter/sqlite3_adapter.rb
@@ -8,14 +8,14 @@ module Exwiw
       end
 
       def execute(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing SQL: \n#{sql}")
         connection.execute(sql)
       end
 
       def explain(query_ast)
-        sql = compile_ast(query_ast)
+        sql = commented_sql(query_ast)
 
         @logger.debug("  Executing EXPLAIN QUERY PLAN: \n#{sql}")
         rows = connection.execute("EXPLAIN QUERY PLAN #{sql}")

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -40,7 +40,7 @@ module Exwiw
         @logger.debug("Explaining '#{table_name}'... (#{idx + 1}/#{total_size})")
 
         query_ast = adapter.build_query(table, @dump_target, table_by_name)
-        sql = adapter.compile_ast(query_ast)
+        sql = adapter.commented_sql(query_ast)
         explain_text = adapter.explain(query_ast)
 
         @io.puts "-- [#{idx + 1}/#{total_size}] #{table_name}"

--- a/spec/adapter/sqlite3_adapter_spec.rb
+++ b/spec/adapter/sqlite3_adapter_spec.rb
@@ -131,6 +131,25 @@ module Exwiw
         end
       end
 
+      describe "#commented_sql" do
+        it "prefixes the compiled SELECT with an exwiw identifier comment" do
+          ast = build_select_shops_ast
+          expect(adapter.commented_sql(ast)).to eq(
+            "/* exwiw table=shops */ #{adapter.compile_ast(ast)}"
+          )
+        end
+
+        it "leaves the bare compile_ast output free of comments (subquery/DELETE reuse)" do
+          expect(adapter.compile_ast(build_select_shops_ast)).not_to include('exwiw')
+        end
+      end
+
+      describe "#query_comment_text" do
+        it "strips comment terminators to prevent breaking out of the comment" do
+          expect(adapter.query_comment_text("table=foo*/DROP")).not_to include('*/')
+        end
+      end
+
       describe "#execute" do
         context "simple select query" do
           let(:results) { adapter.execute(build_select_shops_ast) }


### PR DESCRIPTION
## 概要

exwiw が dump / explain 時に**本番DB**へ発行するクエリの先頭に `/* exwiw table=shops */` 形式の識別用コメントを付与する。

これまでクエリにコメントが無く、本番の processlist / slow query log / `db.currentOp()` 上でどのプロセスが exwiw 由来か判別できなかった。長時間化したときに「どのテーブルの dump か」を見て狙って kill するのが難しい。そこで識別コメントを混ぜて運用時の識別・kill を容易にする。

## 変更内容

- `lib/exwiw/adapter.rb`: `Base` に `query_comment_text` / `sql_query_comment` / `commented_sql` を追加
  - version は snapshot / diff が version bump で揺れるため**埋め込まない**
  - `*/` を除去してコメント終端の誤注入を防止
- `lib/exwiw/adapter/{mysql2,postgresql,sqlite3}_adapter.rb`: `execute` / `explain` を `commented_sql` 経由に
- `lib/exwiw/adapter/mongodb_adapter.rb`: `find` に `.comment("exwiw collection=…")` を付与（`db.currentOp()` に出るため killOp 可能）
- `lib/exwiw/explain_runner.rb`: explain サブコマンドの表示SQLも実送出形（コメント付き）に統一
- `spec/adapter/sqlite3_adapter_spec.rb`: テスト追加

## 方針のポイント

`compile_ast` には**埋め込まず**、`execute` / `explain` / `find` の発行境界だけに付与する。`compile_ast` は `to_bulk_delete` のサブクエリ生成にも再利用されるため、ここを汚すとサブクエリやディスク出力する INSERT/DELETE 文まで汚れる。発行境界に限定することで、生成ファイルはコメントフリーに保たれる。

## 検証

- `bundle exec rspec` → 201 examples, 0 failures（既存 pending 1 のみ）
- sqlite3 explain シナリオで `/* exwiw table=shops */ SELECT …` が前置されることを確認
- sqlite3 dump シナリオで生成 INSERT/DELETE ファイルにコメントが漏れず、DELETE サブクエリもコメント無しなことを確認
- mysql2 / postgresql / mongodb の dump・explain シナリオ全て pass（MongoDB の `.comment()` も実ドライバで動作確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)