### PR TITLE
schema:generate を各DBごとの schema_migrations 対応に揃える

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `schema:generate` now supports Rails multiple-database setups (`connects_to`). Models are bucketed by their database (`connection_db_config.name`, e.g. `primary` / `analytics`) and each database's config files are written into its own subdirectory under `OUTPUT_DIR_PATH` (`exwiw/primary/`, `exwiw/analytics/`, ...). Rails-managed tables (`schema_migrations` / `ar_internal_metadata`) are emitted under whichever database actually owns them. Single-database apps are unaffected and still write flat into the output directory. This replaces the previous behavior of raising `MultipleDatabasesNotSupportedError`.
+
 ## [0.2.5] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ By default, the schema files will be saved in the `exwiw` directory. You can spe
 OUTPUT_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
 ```
 
+#### Multiple databases
+
+If the application uses Rails' multiple-database support (`connects_to`), `schema:generate` buckets models by the database they connect to and writes each database's config files into its own subdirectory of the output directory, named after the database config name (`primary`, `analytics`, ...):
+
+```
+exwiw/
+  primary/
+    shops.json
+    users.json
+    schema_migrations.json
+  analytics/
+    analytics_events.json
+```
+
+Rails-managed tables (`schema_migrations` / `ar_internal_metadata`) are emitted under whichever database actually contains them. Single-database applications are unaffected and continue to write files flat into the output directory.
+
 ### Configuration
 
 This is an example of the one table schema:
@@ -250,7 +266,7 @@ Constraints:
 
 - Defining `primary_key`, `columns`, or `belongs_tos` on a rails-managed entry is rejected with `ArgumentError` on load.
 - A rails-managed table cannot be used as `--target-table`.
-- Multi-database setups are not yet supported — the table name is read from the global `ActiveRecord::Base` accessor.
+- In multi-database setups, the rails-managed entry is emitted under whichever database's connection actually contains the table (see [Multiple databases](#multiple-databases)). The table name itself is still derived from the global `ActiveRecord::Base.schema_migrations_table_name` / `internal_metadata_table_name` (prefix/suffix) accessors.
 
 ### Bulk insert chunk size
 

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -5,8 +5,6 @@ require "json"
 
 module Exwiw
   class SchemaGenerator
-    class MultipleDatabasesNotSupportedError < StandardError; end
-
     def self.from_rails_application(output_dir:)
       Rails.application.eager_load!
       new(models: ActiveRecord::Base.descendants, output_dir: output_dir)
@@ -18,33 +16,53 @@ module Exwiw
     end
 
     def generate!
-      tables = build_tables
-      write_files(tables)
-      tables
+      groups = build_table_groups
+      write_groups(groups)
+      groups
     end
 
-    def build_tables
+    # Returns a Hash keyed by the database name.
+    #
+    # - Single-database setup: the only key is `nil`, signalling that the table
+    #   configs should be written flat into `output_dir` (backwards compatible).
+    # - Multi-database setup (Rails `connects_to`): one key per database
+    #   (`connection_db_config.name`, e.g. "primary" / "analytics"), each
+    #   mapping to that database's table configs. They are written into
+    #   `output_dir/<db_name>/`.
+    def build_table_groups
       models = concrete_models
-      validate_single_database!(models)
+      grouped = models.group_by { |model| database_name_for(model) }
 
-      tables_from_models = models.group_by(&:table_name).map do |table_name, model_group|
-        representative = model_group.first
-        TableConfig.from_symbol_keys(
-          name: table_name,
-          primary_key: representative.primary_key,
-          belongs_tos: aggregate_belongs_tos(model_group),
-          columns: representative.column_names.map { |name| { name: name } },
-        )
+      if grouped.size <= 1
+        conn = models.empty? ? ActiveRecord::Base.connection : models.first.connection
+        return { nil => build_tables_for(models, conn) }
       end
 
-      tables_from_models + build_rails_managed_tables
+      grouped.each_with_object({}) do |(db_name, group_models), result|
+        conn = group_models.first.connection
+        result[db_name] = build_tables_for(group_models, conn)
+      end
     end
 
-    def write_files(tables)
-      FileUtils.mkdir_p(@output_dir)
+    # Backwards-compatible flat list of all table configs. Only meaningful for
+    # a single-database setup; for multi-database setups prefer
+    # `#build_table_groups` so the database association is preserved.
+    def build_tables
+      build_table_groups.values.flatten
+    end
+
+    def write_groups(groups)
+      groups.each do |db_name, tables|
+        dir = db_name.nil? ? @output_dir : File.join(@output_dir, db_name)
+        write_files(dir, tables)
+      end
+    end
+
+    def write_files(dir, tables)
+      FileUtils.mkdir_p(dir)
 
       tables.each do |table|
-        path = File.join(@output_dir, "#{table.name}.json")
+        path = File.join(dir, "#{table.name}.json")
         config_to_write =
           if File.exist?(path)
             TableConfig.from(JSON.parse(File.read(path))).merge(table)
@@ -55,20 +73,31 @@ module Exwiw
       end
     end
 
+    private def build_tables_for(models, conn)
+      tables_from_models = models.group_by(&:table_name).map do |table_name, model_group|
+        representative = model_group.first
+        TableConfig.from_symbol_keys(
+          name: table_name,
+          primary_key: representative.primary_key,
+          belongs_tos: aggregate_belongs_tos(model_group),
+          columns: representative.column_names.map { |name| { name: name } },
+        )
+      end
+
+      tables_from_models + build_rails_managed_tables(conn)
+    end
+
     private def concrete_models
       @models.reject(&:abstract_class?).select(&:table_exists?)
     end
 
-    # NOTE: multi-database setup には未対応。`ActiveRecord::Base.schema_migrations_table_name`
-    # と `internal_metadata_table_name` はクラスレベルのグローバル設定を返すため、
-    # connection 毎にテーブル名が違うケース (`connects_to` で別 DB を扱う場合や
-    # `ActiveRecord::Base` 以外で `connection.schema_migration.table_name` を上書きしている場合)
-    # を拾えない。現状は `validate_single_database!` で multi-DB を弾いているので
-    # ここに到達するのは単一 DB 構成のみという前提で動いている。
-    # multi-DB 対応する際は、対象の connection に紐づく schema_migration から
-    # テーブル名を取り、connection 毎にエントリを生成する必要がある。
-    private def build_rails_managed_tables
-      conn = ActiveRecord::Base.connection
+    # rails-managed テーブル (`schema_migrations` / `ar_internal_metadata`) は
+    # モデルクラスを持たないため `ActiveRecord::Base.descendants` からは拾えない。
+    # multi-DB 構成では各 connection が独立した migration 履歴テーブルを持つので、
+    # 対象 connection を受け取り、その connection 上に該当テーブルが存在する場合のみ
+    # エントリを生成する。テーブル名そのものは prefix/suffix を含むグローバル設定
+    # (`ActiveRecord::Base.schema_migrations_table_name` 等) から得る。
+    private def build_rails_managed_tables(conn)
       result = []
 
       schema_migrations_name = ActiveRecord::Base.schema_migrations_table_name
@@ -108,22 +137,13 @@ module Exwiw
       end
     end
 
-    # `connection_specification_name` is a quasi-private API but has been stable
-    # across Rails 6.1 - 8.x. With Rails multi-DB (`connects_to`), every
-    # descendant of the same abstract base shares one spec name regardless of
-    # role/shard, so distinct values across concrete models indicate genuinely
-    # separate databases.
-    private def validate_single_database!(models)
-      return if models.empty?
-
-      specs = models.map(&:connection_specification_name).uniq
-      return if specs.size <= 1
-
-      raise MultipleDatabasesNotSupportedError, <<~MSG
-        exwiw does not yet support Rails multiple-database setup.
-        Detected connection specifications: #{specs.inspect}
-        Track progress at https://github.com/riseshia/exwiw/issues
-      MSG
+    # Identifies which database a model belongs to. With Rails multi-DB
+    # (`connects_to` backed by `database.yml`), `connection_db_config.name`
+    # returns the configuration name ("primary", "analytics", ...) which is
+    # stable across roles/shards and makes a natural per-database directory
+    # name. Single-database apps all share one name, collapsing into one group.
+    private def database_name_for(model)
+      model.connection_db_config.name
     end
   end
 end

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -67,8 +67,11 @@ module Exwiw
         CREATE TABLE shops (id INTEGER PRIMARY KEY, name TEXT);
         CREATE TABLE schema_migrations (version TEXT NOT NULL PRIMARY KEY);
       SQL
+      # Each database in a Rails multi-DB setup keeps its own migration
+      # history, so analytics also gets a schema_migrations table.
       SQLite3::Database.new(ANALYTICS_DB_PATH).execute_batch(<<~SQL)
         CREATE TABLE analytics_events (id INTEGER PRIMARY KEY);
+        CREATE TABLE schema_migrations (version TEXT NOT NULL PRIMARY KEY);
       SQL
 
       define_models!
@@ -216,12 +219,12 @@ module Exwiw
 
         it "places each model's table in its own database group" do
           expect(groups["primary"].map(&:name)).to include("shops")
-          expect(groups["analytics"].map(&:name)).to contain_exactly("analytics_events")
+          expect(groups["analytics"].map(&:name)).to include("analytics_events")
         end
 
-        it "emits rails-managed tables under the database that owns them" do
+        it "emits each database's own rails-managed schema_migrations table" do
           expect(groups["primary"].map(&:name)).to include("schema_migrations")
-          expect(groups["analytics"].map(&:name)).not_to include("schema_migrations")
+          expect(groups["analytics"].map(&:name)).to include("schema_migrations")
         end
 
         it "collapses into a single nil-keyed group for a single-database setup" do
@@ -237,7 +240,7 @@ module Exwiw
           expect(Dir[File.join(output_dir, "primary", "*.json")].map { |p| File.basename(p) })
             .to contain_exactly("shops.json", "schema_migrations.json")
           expect(Dir[File.join(output_dir, "analytics", "*.json")].map { |p| File.basename(p) })
-            .to contain_exactly("analytics_events.json")
+            .to contain_exactly("analytics_events.json", "schema_migrations.json")
         end
       end
     end

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -38,28 +38,57 @@ module Exwiw
     end
   end
 
-  # Real multi-DB setup: two abstract bases each with their own
-  # AR connection, exercising connection_specification_name without
-  # any stubbing.
+  # Real Rails multi-DB setup: two abstract bases wired through
+  # `connects_to` against named entries in `ActiveRecord::Base.configurations`,
+  # exactly as a `database.yml`-backed app would. This makes
+  # `connection_db_config.name` return "primary" / "analytics", which is what
+  # SchemaGenerator uses to bucket tables into per-database directories.
   module SchemaGeneratorMultiDbFixtures
-    ANALYTICS_DB_PATH = "tmp/test_analytics.sqlite3"
+    PRIMARY_DB_PATH = "tmp/test_multidb_primary.sqlite3"
+    ANALYTICS_DB_PATH = "tmp/test_multidb_analytics.sqlite3"
 
-    class PrimaryAbstract < ::ActiveRecord::Base
-      self.abstract_class = true
-      establish_connection(adapter: "sqlite3", database: database_config("sqlite3").fetch(:database))
+    CONFIGURATIONS = {
+      "test" => {
+        "primary"   => { "adapter" => "sqlite3", "database" => PRIMARY_DB_PATH },
+        "analytics" => { "adapter" => "sqlite3", "database" => ANALYTICS_DB_PATH },
+      },
+    }.freeze
+
+    module_function
+
+    # `connects_to` resolves against `ActiveRecord::Base.configurations` at
+    # class-definition time, so the fixture classes are defined lazily — only
+    # after the surrounding example group has set configurations and RAILS_ENV.
+    def setup!
+      FileUtils.mkdir_p("tmp")
+      [PRIMARY_DB_PATH, ANALYTICS_DB_PATH].each { |p| File.delete(p) if File.exist?(p) }
+
+      SQLite3::Database.new(PRIMARY_DB_PATH).execute_batch(<<~SQL)
+        CREATE TABLE shops (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE TABLE schema_migrations (version TEXT NOT NULL PRIMARY KEY);
+      SQL
+      SQLite3::Database.new(ANALYTICS_DB_PATH).execute_batch(<<~SQL)
+        CREATE TABLE analytics_events (id INTEGER PRIMARY KEY);
+      SQL
+
+      define_models!
     end
 
-    class AnalyticsAbstract < ::ActiveRecord::Base
-      self.abstract_class = true
-      establish_connection(adapter: "sqlite3", database: ANALYTICS_DB_PATH)
-    end
+    def define_models!
+      return if const_defined?(:PrimaryModel, false)
 
-    class PrimaryModel < PrimaryAbstract
-      self.table_name = "shops"
-    end
+      # `connects_to` rejects anonymous classes, so name the class via
+      # const_set before wiring the connection.
+      primary_abstract = Class.new(::ActiveRecord::Base) { self.abstract_class = true }
+      const_set(:PrimaryAbstract, primary_abstract)
+      primary_abstract.connects_to(database: { writing: :primary })
 
-    class AnalyticsModel < AnalyticsAbstract
-      self.table_name = "analytics_events"
+      analytics_abstract = Class.new(::ActiveRecord::Base) { self.abstract_class = true }
+      const_set(:AnalyticsAbstract, analytics_abstract)
+      analytics_abstract.connects_to(database: { writing: :analytics })
+
+      const_set(:PrimaryModel, Class.new(primary_abstract) { self.table_name = "shops" })
+      const_set(:AnalyticsModel, Class.new(analytics_abstract) { self.table_name = "analytics_events" })
     end
   end
 
@@ -157,28 +186,59 @@ module Exwiw
       end
     end
 
-    describe "multi-database detection" do
+    describe "multi-database support" do
       before(:all) do
-        FileUtils.mkdir_p(File.dirname(SchemaGeneratorMultiDbFixtures::ANALYTICS_DB_PATH))
-        # DIRTY: 後にseedで対応するようにする
-        SQLite3::Database.new(SchemaGeneratorMultiDbFixtures::ANALYTICS_DB_PATH).execute_batch(<<~SQL)
-          CREATE TABLE IF NOT EXISTS analytics_events (id INTEGER PRIMARY KEY);
-        SQL
+        @previous_env = ENV["RAILS_ENV"]
+        @previous_configs = ActiveRecord::Base.configurations
+        ENV["RAILS_ENV"] = "test"
+        ActiveRecord::Base.configurations = SchemaGeneratorMultiDbFixtures::CONFIGURATIONS
+        SchemaGeneratorMultiDbFixtures.setup!
       end
 
-      it "raises when concrete models point to different connection specifications" do
-        models = [
+      after(:all) do
+        ActiveRecord::Base.configurations = @previous_configs
+        ENV["RAILS_ENV"] = @previous_env
+      end
+
+      let(:multidb_models) do
+        [
           SchemaGeneratorMultiDbFixtures::PrimaryModel,
           SchemaGeneratorMultiDbFixtures::AnalyticsModel,
         ]
-        generator = described_class.new(models: models, output_dir: output_dir)
-        expect { generator.build_tables }
-          .to raise_error(SchemaGenerator::MultipleDatabasesNotSupportedError, /multiple-database/)
       end
 
-      it "does not raise when all models share the same connection specification" do
-        generator = described_class.new(models: [Shop, User], output_dir: output_dir)
-        expect { generator.build_tables }.not_to raise_error
+      describe "#build_table_groups" do
+        let(:groups) { described_class.new(models: multidb_models, output_dir: output_dir).build_table_groups }
+
+        it "buckets tables by their database config name" do
+          expect(groups.keys).to contain_exactly("primary", "analytics")
+        end
+
+        it "places each model's table in its own database group" do
+          expect(groups["primary"].map(&:name)).to include("shops")
+          expect(groups["analytics"].map(&:name)).to contain_exactly("analytics_events")
+        end
+
+        it "emits rails-managed tables under the database that owns them" do
+          expect(groups["primary"].map(&:name)).to include("schema_migrations")
+          expect(groups["analytics"].map(&:name)).not_to include("schema_migrations")
+        end
+
+        it "collapses into a single nil-keyed group for a single-database setup" do
+          single = described_class.new(models: [SchemaGeneratorMultiDbFixtures::PrimaryModel], output_dir: output_dir)
+          expect(single.build_table_groups.keys).to eq([nil])
+        end
+      end
+
+      describe "#generate!" do
+        it "writes each database's tables into its own subdirectory" do
+          described_class.new(models: multidb_models, output_dir: output_dir).generate!
+
+          expect(Dir[File.join(output_dir, "primary", "*.json")].map { |p| File.basename(p) })
+            .to contain_exactly("shops.json", "schema_migrations.json")
+          expect(Dir[File.join(output_dir, "analytics", "*.json")].map { |p| File.basename(p) })
+            .to contain_exactly("analytics_events.json")
+        end
       end
     end
 


### PR DESCRIPTION
## 概要

Rails multi-DB 構成では各データベースが独立した migration 履歴テーブル（`schema_migrations`）を持つ。本番ロジック（`build_rails_managed_tables(conn)`）は既に connection ごとに `table_exists?` をチェックして出力する実装になっていたが、テスト環境が analytics DB に `schema_migrations` を作っておらず「analytics には無い」前提になっていた。

各DBが自分の `schema_migrations` を持つ現実的な構成にテストを揃えた。

## 変更点

- analytics DB の fixture に `schema_migrations` テーブルを追加
- 両DBから `schema_migrations` が出力されることを検証するようテストを更新
- `generate!` のディレクトリ検証で analytics 側にも `schema_migrations.json` が出ることを反映

## テスト

`bundle exec rspec spec/schema_generator_spec.rb` → 17 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)