### PR TITLE
feat(schema_generator): 複合主キーのテーブルを skip:true で出力する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `schema:generate` no longer crashes on models with a composite primary key (`primary_key` returns an Array). Such tables are emitted with `skip: true`, tagged `type: "unsupported_composite_primary_key"`, and annotated with a `comment` listing the key columns. `columns` / `belongs_tos` are retained so the entry can be wired up once composite-key support lands; for now `skip: true` excludes it from extraction. `skip: true` tables no longer require `primary_key` at load time.
+
+### Notes
+
+- `schema:generate` multi-database support: each database keeps its own Rails migration history, so a per-database `schema_migrations` / `ar_internal_metadata` entry is emitted for every database that has one. Known limitation: the rails-managed table *name* is resolved from the global `ActiveRecord::Base.schema_migrations_table_name` / `internal_metadata_table_name` accessors, so a per-database override of those names is not detected and the table will be missing from that database's generated configs.
+
 ## [0.2.6] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ exwiw/
     analytics_events.json
 ```
 
-Rails-managed tables (`schema_migrations` / `ar_internal_metadata`) are emitted under whichever database actually contains them. Single-database applications are unaffected and continue to write files flat into the output directory.
+Each database keeps its own Rails migration history, so a `schema_migrations` (and `ar_internal_metadata`) entry is emitted under every database that contains one — the example above shows `primary/schema_migrations.json` and would also produce `analytics/schema_migrations.json` when the analytics database has its own migration table. Single-database applications are unaffected and continue to write files flat into the output directory.
+
+**Limitations**
+
+- The rails-managed table *names* are resolved from the global `ActiveRecord::Base.schema_migrations_table_name` / `internal_metadata_table_name` accessors, which are shared across all connections. A per-database override of these names is not detected, so such a table will be missing from that database's generated configs.
 
 ### Configuration
 
@@ -267,6 +271,23 @@ Constraints:
 - Defining `primary_key`, `columns`, or `belongs_tos` on a rails-managed entry is rejected with `ArgumentError` on load.
 - A rails-managed table cannot be used as `--target-table`.
 - In multi-database setups, the rails-managed entry is emitted under whichever database's connection actually contains the table (see [Multiple databases](#multiple-databases)). The table name itself is still derived from the global `ActiveRecord::Base.schema_migrations_table_name` / `internal_metadata_table_name` (prefix/suffix) accessors.
+
+### Composite primary keys (unsupported)
+
+exwiw does not yet support tables with a composite primary key. When `exwiw:schema:generate` encounters a model whose `primary_key` is an array, it still emits a config entry so the table is not silently dropped, but marks it `skip: true`, tags it `type: "unsupported_composite_primary_key"`, and records the key columns in a `comment`:
+
+```json
+{
+  "name": "composite_pk_records",
+  "type": "unsupported_composite_primary_key",
+  "skip": true,
+  "comment": "exwiw does not support composite primary keys (organization_id, location_id); data extraction is skipped.",
+  "belongs_tos": [],
+  "columns": [{ "name": "organization_id" }, { "name": "location_id" }, { "name": "name" }]
+}
+```
+
+Unlike rails-managed entries, `columns` and `belongs_tos` are retained so the entry is ready to wire up once composite-key support lands. The `type` is purely a marker — `skip: true` is what actually excludes the table from extraction, so removing `skip` (and supplying a workable `primary_key`) lets you opt the table back in manually.
 
 ### Bulk insert chunk size
 

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -76,12 +76,28 @@ module Exwiw
     private def build_tables_for(models, conn)
       tables_from_models = models.group_by(&:table_name).map do |table_name, model_group|
         representative = model_group.first
-        TableConfig.from_symbol_keys(
-          name: table_name,
-          primary_key: representative.primary_key,
-          belongs_tos: aggregate_belongs_tos(model_group),
-          columns: representative.column_names.map { |name| { name: name } },
-        )
+        primary_key = representative.primary_key
+
+        # 複合主キー (`representative.primary_key` が Array) のテーブルは現状未対応。
+        # primary_key を省略し skip:true を付与して出力する。利用者が必要に応じて
+        # 手動で skip を外して設定し直せるよう、設定ファイル自体は生成しておく。
+        if primary_key.is_a?(Array)
+          TableConfig.from_symbol_keys(
+            name: table_name,
+            skip: true,
+            comment: "exwiw does not support composite primary keys " \
+                     "(#{primary_key.join(', ')}); data extraction is skipped.",
+            belongs_tos: aggregate_belongs_tos(model_group),
+            columns: representative.column_names.map { |name| { name: name } },
+          )
+        else
+          TableConfig.from_symbol_keys(
+            name: table_name,
+            primary_key: primary_key,
+            belongs_tos: aggregate_belongs_tos(model_group),
+            columns: representative.column_names.map { |name| { name: name } },
+          )
+        end
       end
 
       tables_from_models + build_rails_managed_tables(conn)

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -79,11 +79,14 @@ module Exwiw
         primary_key = representative.primary_key
 
         # 複合主キー (`representative.primary_key` が Array) のテーブルは現状未対応。
-        # primary_key を省略し skip:true を付与して出力する。利用者が必要に応じて
-        # 手動で skip を外して設定し直せるよう、設定ファイル自体は生成しておく。
+        # primary_key を省略し、type で非対応である旨を明示したうえで skip:true を
+        # 付与して出力する。type を付けておくことで将来対応する際の目印になる。
+        # 利用者が必要に応じて手動で skip を外して設定し直せるよう、設定ファイル
+        # 自体は生成しておく。
         if primary_key.is_a?(Array)
           TableConfig.from_symbol_keys(
             name: table_name,
+            type: TableConfig::UNSUPPORTED_COMPOSITE_PRIMARY_KEY,
             skip: true,
             comment: "exwiw does not support composite primary keys " \
                      "(#{primary_key.join(', ')}); data extraction is skipped.",

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -138,7 +138,9 @@ module Exwiw
                 "Table '#{name}' has type=#{type}; columns must not be defined."
         end
       else
-        if primary_key.nil?
+        # skip:true のテーブルはデータ抽出を行わないため primary_key を要求しない。
+        # (例: exwiw 非対応の複合主キーテーブル)
+        if primary_key.nil? && !skip
           raise ArgumentError, "Table '#{name}' requires primary_key."
         end
       end

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -11,6 +11,11 @@ module Exwiw
       RAILS_MANAGED_INTERNAL_METADATA,
     ].freeze
 
+    # exwiw が現状サポートしていない複合主キーのテーブルを表す type。
+    # schema:generate が skip:true と併せて付与する。将来サポートする際の
+    # 目印になるよう、rails-managed とは異なり columns/belongs_tos は保持する。
+    UNSUPPORTED_COMPOSITE_PRIMARY_KEY = "unsupported_composite_primary_key"
+
     attribute :name, String
     attribute :primary_key, optional(String), skip_serializing_if_nil: true
     attribute :type, optional(String), skip_serializing_if_nil: true

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -225,6 +225,10 @@ module Exwiw
         expect(table.primary_key).to be_nil
       end
 
+      it "tags the table with the unsupported_composite_primary_key type" do
+        expect(table.type).to eq(TableConfig::UNSUPPORTED_COMPOSITE_PRIMARY_KEY)
+      end
+
       it "records that exwiw does not support composite primary keys in the comment" do
         expect(table.comment).to include("does not support composite primary keys")
         expect(table.comment).to include("organization_id", "location_id")

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -36,6 +36,14 @@ module Exwiw
     class ChildBelongsToUser < ParentNoBelongsTo
       belongs_to :user, class_name: "::User"
     end
+
+    # Composite primary key model. `representative.primary_key` returns an Array
+    # for these, which exwiw does not support; the generator must mark them
+    # skip:true instead of raising on the TableConfig type check.
+    class CompositePkRecord < ::ActiveRecord::Base
+      self.table_name = "composite_pk_records"
+      self.primary_key = [:organization_id, :location_id]
+    end
   end
 
   # Real Rails multi-DB setup: two abstract bases wired through
@@ -186,6 +194,44 @@ module Exwiw
 
         belongs_tos = tables.first.belongs_tos.map { |b| [b.table_name, b.foreign_key] }
         expect(belongs_tos).to contain_exactly(["shops", "shop_id"], ["users", "user_id"])
+      end
+    end
+
+    describe "composite primary key" do
+      before(:all) do
+        ActiveRecord::Base.connection.execute(<<~SQL)
+          CREATE TABLE IF NOT EXISTS composite_pk_records (
+            organization_id INTEGER NOT NULL,
+            location_id INTEGER NOT NULL,
+            name TEXT,
+            PRIMARY KEY (organization_id, location_id)
+          )
+        SQL
+      end
+
+      after(:all) do
+        ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS composite_pk_records")
+      end
+
+      let(:table) do
+        described_class
+          .new(models: [SchemaGeneratorStiFixtures::CompositePkRecord], output_dir: output_dir)
+          .build_tables
+          .find { |t| t.name == "composite_pk_records" }
+      end
+
+      it "emits the table with skip:true and no primary_key" do
+        expect(table.skip).to eq(true)
+        expect(table.primary_key).to be_nil
+      end
+
+      it "records that exwiw does not support composite primary keys in the comment" do
+        expect(table.comment).to include("does not support composite primary keys")
+        expect(table.comment).to include("organization_id", "location_id")
+      end
+
+      it "still captures columns" do
+        expect(table.column_names).to include("organization_id", "location_id", "name")
       end
     end
 


### PR DESCRIPTION
## 概要

`exwiw:schema:generate` が複合主キー（`primary_key` が Array を返すモデル）で落ちる問題に対応する。複合主キーは exwiw 非対応のため、設定ファイル自体は生成しつつ抽出対象から除外する。

## 変更点

### 複合主キーテーブルの扱い
- 複合主キーのテーブルを `skip: true` で出力（設定ファイルは残し、利用者が必要に応じて手動で skip を外せる）
- 非対応である旨と主キー列を `comment` に記録
- `type: "unsupported_composite_primary_key"` を付与。将来 exwiw が複合主キーに対応する際の目印になる。rails-managed type と異なり `columns` / `belongs_tos` は保持する
- `skip: true` のテーブルは `primary_key` を要求しないよう `validate_after_load!` を緩和

### ドキュメント
- README に「Composite primary keys (unsupported)」セクションを追加
- multi-DB 構成で各DBごとに `schema_migrations` 等が出力されること、テーブル名がグローバル accessor から解決される制約を README / CHANGELOG に追記
- CHANGELOG `[Unreleased]` を更新

## テスト

`bundle exec rspec spec/schema_generator_spec.rb spec/table_config_spec.rb` → 40 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)