### PR TITLE
export前にoutput-dirの中身を空にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `export` now empties `--output-dir` before writing, so a run never mixes files from a previous export. When running interactively (stdin is a tty) and the dir already has contents, exwiw asks for confirmation before removing them; in non-interactive contexts (CI, pipes) it proceeds without prompting.
+
 ## [0.3.3] - 2026-05-31
 
 ## [0.3.2] - 2026-05-31

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ exwiw \
 
 This command will generate sql files in the `dump` directory.
 
+The output dir is emptied before each export so it never mixes files from a previous run (defaulting to `dump/` when `--output-dir` is omitted). When run interactively (stdin is a tty) and the dir already contains files, exwiw asks for confirmation before removing them; in non-interactive contexts (CI, pipes) it proceeds without prompting.
+
 - `dump/insert-000-schema.sql` — idempotent `CREATE TABLE IF NOT EXISTS ...` for every table in scope. Apply this first to provision an empty database.
 - `dump/insert-{idx}-{table_name}.sql`
 - `dump/delete-{idx}-{table_name}.sql`

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -76,6 +76,7 @@ module Exwiw
 
       case @subcommand
       when "export"
+        confirm_output_dir_clear!
         Runner.new(
           connection_config: connection_config,
           output_dir: @output_dir,
@@ -270,6 +271,28 @@ module Exwiw
       end
     end
 
+    # The export clears @output_dir before writing (see Runner#clean_output_dir!).
+    # That is destructive, so when running interactively (stdin is a tty) ask for
+    # confirmation first. In non-interactive contexts (CI, pipes) we proceed
+    # without prompting. Only prompt when there is actually something to delete.
+    private def confirm_output_dir_clear!
+      return unless $stdin.tty?
+      return unless Dir.exist?(@output_dir)
+
+      entries = Dir.each_child(@output_dir).to_a
+      return if entries.empty?
+
+      $stderr.puts "All contents of the output dir will be removed before export:"
+      $stderr.puts "  #{@output_dir} (#{entries.size} entr#{entries.size == 1 ? 'y' : 'ies'})"
+      $stderr.print "Continue? [y/N]: "
+
+      answer = $stdin.gets&.strip&.downcase
+      unless answer == "y" || answer == "yes"
+        $stderr.puts "Aborted."
+        exit 1
+      end
+    end
+
     private def build_cli_options_hash
       {
         database_host: @database_host,
@@ -322,7 +345,7 @@ module Exwiw
         opts.on("-h", "--host=HOST", "Target database host") { |v| @database_host = v }
         opts.on("-p", "--port=PORT", "Target database port") { |v| @database_port = v }
         opts.on("-u", "--user=USERNAME", "Target database user") { |v| @database_user = v }
-        opts.on("-o", "--output-dir=[DUMP_DIR_PATH]", "Output file path. default is dump/ (export subcommand only)") do |v|
+        opts.on("-o", "--output-dir=[DUMP_DIR_PATH]", "Output file path. default is dump/. Its contents are emptied before each export (export subcommand only)") do |v|
           v = v.end_with?("/") ? v[0..-2] : v
           @output_dir = File.expand_path(v)
         end

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -41,9 +41,7 @@ module Exwiw
       @logger.info("Determining table processing order...")
       ordered_table_names = DetermineTableProcessingOrder.run(configs.select { |c| adapter.dumpable?(c) })
 
-      if !Dir.exist?(@output_dir)
-        FileUtils.mkdir_p(@output_dir)
-      end
+      clean_output_dir!
 
       ordered_tables = ordered_table_names.map { |n| table_by_name.fetch(n) }
       schema_path = File.join(@output_dir, "insert-000-schema.#{adapter.schema_output_extension}")
@@ -120,6 +118,23 @@ module Exwiw
           output_extension: adapter.output_extension,
           logger: @logger,
         )
+      end
+    end
+
+    # Empty the output dir before writing so each export starts from a clean
+    # slate and never mixes files from a previous run. Remove the contents
+    # (including dotfiles) rather than the dir itself, preserving the dir's own
+    # permissions/inode. The CLI is responsible for confirming this with the
+    # user when running interactively.
+    private def clean_output_dir!
+      if Dir.exist?(@output_dir)
+        entries = Dir.each_child(@output_dir).to_a
+        unless entries.empty?
+          @logger.info("Cleaning output dir #{@output_dir} (#{entries.size} entr#{entries.size == 1 ? 'y' : 'ies'})...")
+          entries.each { |entry| FileUtils.rm_rf(File.join(@output_dir, entry)) }
+        end
+      else
+        FileUtils.mkdir_p(@output_dir)
       end
     end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'exwiw/cli'
+require 'tmpdir'
+require 'fileutils'
 
 module Exwiw
   RSpec.describe CLI do
@@ -155,6 +157,63 @@ module Exwiw
                 '--target-collection=users', '--ids=1']
         expect { run_cli(argv) }.to raise_error(SystemExit)
           .and output(/Specify only one of --target-table and --target-collection/).to_stderr
+      end
+    end
+
+    describe 'output dir clear confirmation' do
+      around do |example|
+        Dir.mktmpdir do |dir|
+          @output_dir = dir
+          example.run
+        end
+      end
+
+      def cli_with_output_dir
+        cli = CLI.new(['--adapter=sqlite', '--database=tmp/test.sqlite3', '--config-dir=scenario/sqlite-schema'])
+        cli.instance_variable_set(:@output_dir, @output_dir)
+        cli
+      end
+
+      it 'does not prompt when stdin is not a tty' do
+        File.write(File.join(@output_dir, 'stale.sql'), 'x')
+        allow($stdin).to receive(:tty?).and_return(false)
+        expect($stdin).not_to receive(:gets)
+
+        expect { cli_with_output_dir.send(:confirm_output_dir_clear!) }.not_to raise_error
+      end
+
+      it 'does not prompt on a tty when the output dir is empty' do
+        allow($stdin).to receive(:tty?).and_return(true)
+        expect($stdin).not_to receive(:gets)
+
+        expect { cli_with_output_dir.send(:confirm_output_dir_clear!) }.not_to raise_error
+      end
+
+      it 'proceeds when the user answers yes on a tty' do
+        File.write(File.join(@output_dir, 'stale.sql'), 'x')
+        allow($stdin).to receive(:tty?).and_return(true)
+        allow($stdin).to receive(:gets).and_return("y\n")
+
+        expect { cli_with_output_dir.send(:confirm_output_dir_clear!) }
+          .to output(/All contents of the output dir will be removed/).to_stderr
+      end
+
+      it 'aborts when the user declines on a tty' do
+        File.write(File.join(@output_dir, 'stale.sql'), 'x')
+        allow($stdin).to receive(:tty?).and_return(true)
+        allow($stdin).to receive(:gets).and_return("n\n")
+
+        expect { cli_with_output_dir.send(:confirm_output_dir_clear!) }
+          .to raise_error(SystemExit).and output(/Aborted/).to_stderr
+      end
+
+      it 'aborts on empty input (default is no)' do
+        File.write(File.join(@output_dir, 'stale.sql'), 'x')
+        allow($stdin).to receive(:tty?).and_return(true)
+        allow($stdin).to receive(:gets).and_return("\n")
+
+        expect { cli_with_output_dir.send(:confirm_output_dir_clear!) }
+          .to raise_error(SystemExit).and output(/Aborted/).to_stderr
       end
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -42,6 +42,40 @@ module Exwiw
       expect { runner.run }.not_to raise_error
     end
 
+    describe 'output dir cleaning' do
+      it 'removes pre-existing contents of the output dir before export' do
+        stale_file = File.join(output_dir, 'insert-999-stale.sql')
+        stale_dir = File.join(output_dir, 'leftover')
+        dotfile = File.join(output_dir, '.hidden')
+        File.write(stale_file, 'stale')
+        FileUtils.mkdir_p(stale_dir)
+        File.write(dotfile, 'hidden')
+
+        runner.run
+
+        expect(File.exist?(stale_file)).to be(false)
+        expect(File.exist?(stale_dir)).to be(false)
+        expect(File.exist?(dotfile)).to be(false)
+        expect(Dir[File.join(output_dir, 'insert-000-schema.sql')]).not_to be_empty
+      end
+
+      it 'creates the output dir when it does not exist' do
+        missing = File.join(output_dir, 'nested', 'out')
+        runner_for_missing = Runner.new(
+          connection_config: connection_config,
+          output_dir: missing,
+          config_dir: config_dir,
+          dump_target: dump_target,
+          logger: ::Logger.new(nil),
+        )
+
+        runner_for_missing.run
+
+        expect(Dir.exist?(missing)).to be(true)
+        expect(Dir[File.join(missing, 'insert-000-schema.sql')]).not_to be_empty
+      end
+    end
+
     describe 'with bulk_insert_chunk_size' do
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2', '3', '4', '5']) }
       let(:insert_sql_regex) { /INSERT INTO shops .+ VALUES\n\([^)]+\)(?:,\n\([^)]+\))*;/ }


### PR DESCRIPTION
## 概要

`--output-dir` の中身を毎回空にした上で export するようにしました。前回の export のファイルが残って混ざることがなくなります。

## 変更点

- **`lib/exwiw/runner.rb`**: `clean_output_dir!` を追加。export 開始時に出力ディレクトリの中身（ドットファイル・サブディレクトリ含む）を削除する。ディレクトリ自体は残し、存在しない場合は作成する。
- **`lib/exwiw/cli.rb`**: `confirm_output_dir_clear!` を追加。**stdin が tty のとき**だけ、削除対象を提示して `Continue? [y/N]:` の確認を出す。`y`/`yes` 以外は中断 (`exit 1`)。非対話 (CI・パイプ) や空ディレクトリの場合はプロンプトなしで続行する。
- README / CLI ヘルプ / CHANGELOG に挙動を追記。
- spec を追加（runner の削除挙動、CLI の tty 確認の各ケース）。

## 確認

- 全 spec パス。
- sqlite シナリオで実際に CLI を実行し、stale ファイル（ドットファイル・サブディレクトリ含む）が削除され、非対話時はプロンプトなしで進むことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)