### PR TITLE
feat(config): belongs_to/columns に comment・ignore を追加し skip を ignore にリネーム

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** the table/collection-level config attribute `skip` is renamed to `ignore`. There is no alias — config files using `"skip": true` must be updated to `"ignore": true` (`exwiw:schema:generate` / `exwiw:mongoid:schema:generate` now emit `ignore`, e.g. for composite-primary-key tables). The library accessors are renamed accordingly (`TableConfig#skip` → `#ignore`, `MongodbCollectionConfig#skip` → `#ignore`).
+
+### Added
+
+- `columns` / `fields` and `belongs_tos` entries now accept optional `comment` (a free-form note) and `ignore: true`. An ignored column/field is excluded from the `SELECT` and generated `INSERT`; an ignored `belongs_to` is removed from dependency ordering and query building. These user-owned values are preserved across `exwiw:schema:generate` / `exwiw:mongoid:schema:generate` regenerations (the hand-edited value wins over the auto-generated config), like `replace_with`. The ignored entries are dropped at runtime right after the config is loaded from file, so the JSON on disk keeps them. Applies to both the SQL `TableConfig` and the MongoDB `MongodbCollectionConfig`.
+
 ## [0.3.3] - 2026-05-31
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ It is a distinct task and class (`Exwiw::MongoidSchemaGenerator`) from the Activ
 
 Models in an inheritance hierarchy whose subclasses share the base's collection (Mongoid STI, distinguished by the auto-added `_type` discriminator) collapse into a single config: the generator discovers the subclasses via `descendants` (Mongoid registers only the base class in `Mongoid.models`) and unions every class's `fields` and `belongs_tos` into the collection config, so subclass-only fields and associations are not lost.
 
-Regeneration preserves hand-edited `replace_with`, `filter`, `skip`, and `bulk_insert_chunk_size` values, like the ActiveRecord generator. Indexes are not written to the config — they are introspected from the live database at dump time (see [MongoDB notes](#mongodb-notes)). Polymorphic `belongs_to` is not yet expanded by this task.
+Regeneration preserves hand-edited `replace_with`, `filter`, `ignore`, and `bulk_insert_chunk_size` values, like the ActiveRecord generator. Indexes are not written to the config — they are introspected from the live database at dump time (see [MongoDB notes](#mongodb-notes)). Polymorphic `belongs_to` is not yet expanded by this task.
 
 ### Configuration
 
@@ -256,15 +256,15 @@ A non-zero exit code from the shell hook aborts exwiw.
 
 Note: Ruby hooks are evaluated via `instance_eval` inside the exwiw process — only pass paths you trust.
 
-### Skip a table
+### Ignore a table
 
-Set `"skip": true` on a table's config JSON to exclude it from data extraction. The table's DDL is still emitted into `insert-000-schema.{sql,js}` so the schema stays consistent, but no `insert-*` / `delete-*` files are generated for it and the table is never queried.
+Set `"ignore": true` on a table's config JSON to exclude it from data extraction. The table's DDL is still emitted into `insert-000-schema.{sql,js}` so the schema stays consistent, but no `insert-*` / `delete-*` files are generated for it and the table is never queried.
 
 ```json
 {
   "name": "audit_logs",
   "primary_key": "id",
-  "skip": true,
+  "ignore": true,
   "belongs_tos": [],
   "columns": [{ "name": "id" }]
 }
@@ -272,9 +272,33 @@ Set `"skip": true` on a table's config JSON to exclude it from data extraction. 
 
 Constraints:
 
-- If another non-skipped table has a `belongs_to` entry pointing at a skipped table, exwiw raises `ArgumentError` on load. Remove the `belongs_to` entry on the referencing table, or unset `skip` on the referenced table.
-- Specifying a skipped table as `--target-table` raises `ArgumentError`.
-- `skip: true` is preserved by `exwiw:schema:generate` regenerations (the receiver value wins over the auto-generated config).
+- If another non-ignored table has a `belongs_to` entry pointing at an ignored table, exwiw raises `ArgumentError` on load. Remove the `belongs_to` entry on the referencing table, or unset `ignore` on the referenced table.
+- Specifying an ignored table as `--target-table` raises `ArgumentError`.
+- `ignore: true` is preserved by `exwiw:schema:generate` regenerations (the receiver value wins over the auto-generated config).
+
+### Ignore / annotate a column or `belongs_to`
+
+Individual `columns` (SQL) / `fields` (MongoDB) and `belongs_tos` entries accept two optional, **user-owned** keys:
+
+- `comment` — a free-form note. Purely informational; exwiw never reads it.
+- `ignore: true` — drops that entry from extraction. An ignored column/field is excluded from the `SELECT` and the generated `INSERT` (the column still exists in the target schema, since the DDL comes from the source database — exwiw just does not copy its data). An ignored `belongs_to` is removed from dependency ordering and query building, so the relation is not traversed.
+
+```json
+{
+  "name": "users",
+  "primary_key": "id",
+  "belongs_tos": [
+    { "table_name": "companies", "foreign_key": "company_id" },
+    { "table_name": "audit_logs", "foreign_key": "log_id", "ignore": true, "comment": "huge table, not needed for this export" }
+  ],
+  "columns": [
+    { "name": "id" },
+    { "name": "secret_token", "ignore": true, "comment": "do not copy credentials" }
+  ]
+}
+```
+
+The ignored entries are removed only at runtime, right after the config is loaded from file; the JSON on disk keeps them. Both `comment` and `ignore` are **preserved across `exwiw:schema:generate` / `exwiw:mongoid:schema:generate` regenerations** (the hand-edited value wins over the auto-generated config), just like `replace_with`. This applies to the MongoDB `MongodbCollectionConfig` (`fields` / `belongs_tos`) as well.
 
 ### Polymorphic `belongs_to`
 
@@ -350,20 +374,20 @@ Constraints:
 
 ### Composite primary keys (unsupported)
 
-exwiw does not yet support tables with a composite primary key. When `exwiw:schema:generate` encounters a model whose `primary_key` is an array, it still emits a config entry so the table is not silently dropped, but marks it `skip: true`, tags it `type: "unsupported_composite_primary_key"`, and records the key columns in a `comment`:
+exwiw does not yet support tables with a composite primary key. When `exwiw:schema:generate` encounters a model whose `primary_key` is an array, it still emits a config entry so the table is not silently dropped, but marks it `ignore: true`, tags it `type: "unsupported_composite_primary_key"`, and records the key columns in a `comment`:
 
 ```json
 {
   "name": "composite_pk_records",
   "type": "unsupported_composite_primary_key",
-  "skip": true,
+  "ignore": true,
   "comment": "exwiw does not support composite primary keys (organization_id, location_id); data extraction is skipped.",
   "belongs_tos": [],
   "columns": [{ "name": "organization_id" }, { "name": "location_id" }, { "name": "name" }]
 }
 ```
 
-Unlike rails-managed entries, `columns` and `belongs_tos` are retained so the entry is ready to wire up once composite-key support lands. The `type` is purely a marker — `skip: true` is what actually excludes the table from extraction, so removing `skip` (and supplying a workable `primary_key`) lets you opt the table back in manually.
+Unlike rails-managed entries, `columns` and `belongs_tos` are retained so the entry is ready to wire up once composite-key support lands. The `type` is purely a marker — `ignore: true` is what actually excludes the table from extraction, so removing `ignore` (and supplying a workable `primary_key`) lets you opt the table back in manually.
 
 ### Bulk insert chunk size
 

--- a/lib/exwiw/belongs_to.rb
+++ b/lib/exwiw/belongs_to.rb
@@ -12,6 +12,12 @@ module Exwiw
     # non-polymorphic belongs_to.
     attribute :foreign_type, optional(String), skip_serializing_if_nil: true
     attribute :type_value, optional(String), skip_serializing_if_nil: true
+    # User-owned fields. The schema generators never emit them, but a user can
+    # add them by hand and they survive regeneration (see TableConfig#merge /
+    # MongodbCollectionConfig#merge). `ignore:true` drops the relation from
+    # extraction once the config is loaded (see #reject_ignored_members!).
+    attribute :comment, optional(String), skip_serializing_if_nil: true
+    attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     def self.from_symbol_keys(hash)
       from(hash.transform_keys(&:to_s))
@@ -19,6 +25,13 @@ module Exwiw
 
     def polymorphic?
       !foreign_type.nil?
+    end
+
+    # Structural identity used to match a freshly generated belongs_to against a
+    # user-maintained one during merge. `comment`/`ignore` are user-owned and so
+    # are intentionally excluded.
+    def identity
+      [table_name, foreign_key, foreign_type, type_value]
     end
 
     def to_hash

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -19,7 +19,7 @@ module Exwiw
     def run
       adapter = Adapter.build(@connection_config, @logger)
       configs = load_table_config(adapter.class.table_config_class)
-      validate_skipped(configs)
+      validate_ignored(configs)
 
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
@@ -32,8 +32,8 @@ module Exwiw
       total_size = ordered_table_names.size
       ordered_table_names.each_with_index do |table_name, idx|
         table = table_by_name.fetch(table_name)
-        if table.skip
-          @logger.debug("Skipping explain for '#{table_name}' (skip:true)")
+        if table.ignore
+          @logger.debug("Skipping explain for '#{table_name}' (ignore:true)")
           next
         end
 
@@ -55,30 +55,30 @@ module Exwiw
     private def load_table_config(klass)
       Dir[File.join(@config_dir, "*.json")].map do |file|
         json = JSON.parse(File.read(file))
-        klass.from(json)
+        klass.from(json).reject_ignored_members!
       end
     end
 
-    private def validate_skipped(configs)
-      skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
-      return if skipped_names.empty?
+    private def validate_ignored(configs)
+      ignored_names = configs.select { |c| c.ignore }.map(&:name).to_set
+      return if ignored_names.empty?
 
       configs.each do |config|
-        next if config.skip
+        next if config.ignore
         next unless config.respond_to?(:belongs_tos)
 
-        dangling = config.belongs_tos.select { |rel| skipped_names.include?(rel.table_name) }
+        dangling = config.belongs_tos.select { |rel| ignored_names.include?(rel.table_name) }
         next if dangling.empty?
 
         raise ArgumentError,
-              "Table '#{config.name}' has belongs_to references to skipped table(s): " \
+              "Table '#{config.name}' has belongs_to references to ignored table(s): " \
               "#{dangling.map(&:table_name).join(', ')}. " \
-              "Remove the belongs_to entries or unset `skip` on the referenced table."
+              "Remove the belongs_to entries or unset `ignore` on the referenced table."
       end
 
-      if @dump_target.table_name && skipped_names.include?(@dump_target.table_name)
+      if @dump_target.table_name && ignored_names.include?(@dump_target.table_name)
         raise ArgumentError,
-              "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
+              "--target-table '#{@dump_target.table_name}' is marked ignore:true and cannot be used as a dump target."
       end
     end
   end

--- a/lib/exwiw/mongodb_collection_config.rb
+++ b/lib/exwiw/mongodb_collection_config.rb
@@ -13,7 +13,7 @@ module Exwiw
     attribute :belongs_tos, array(BelongsTo)
     attribute :fields, array(MongodbField)
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
-    attribute :skip, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
+    attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     # Marks this config as physically embedded inside another collection's
     # documents. When set, this config is not processed as a standalone dump
@@ -35,12 +35,21 @@ module Exwiw
       !embedded_in.nil?
     end
 
+    # Drop the belongs_tos/fields flagged `ignore:true` so they are excluded from
+    # extraction. The config files on disk keep these entries; this is applied to
+    # the runtime config right after it is loaded (see Runner#load_table_config).
+    def reject_ignored_members!
+      self.belongs_tos = belongs_tos.reject(&:ignore)
+      self.fields = fields.reject(&:ignore)
+      self
+    end
+
     # Merge an auto-generated config (`passed`) into this user-maintained one so
     # that `MongoidSchemaGenerator` regenerations preserve hand-edited values.
     #
     # - structural facts come from the freshly generated config: primary_key,
     #   belongs_tos, embedded_in.
-    # - user customizations are kept from the receiver: filter, skip,
+    # - user customizations are kept from the receiver: filter, ignore,
     #   bulk_insert_chunk_size, and each field's `replace_with` masking rule.
     # - generated fields drive the field list (so added/removed fields track the
     #   model), but a matching receiver field wins to retain its masking.
@@ -51,18 +60,34 @@ module Exwiw
         merged.name = name
         merged.primary_key = passed.primary_key
         merged.filter = filter
-        merged.belongs_tos = passed.belongs_tos
         merged.bulk_insert_chunk_size = bulk_insert_chunk_size
-        merged.skip = skip
+        merged.ignore = ignore
         merged.embedded_in = passed.embedded_in
+
+        # Structural facts of each belongs_to come from the freshly generated
+        # config, but the user-owned `comment`/`ignore` carry over when the same
+        # relation still exists.
+        receiver_belongs_to_by_identity = belongs_tos.each_with_object({}) { |bt, h| h[bt.identity] = bt }
+        merged.belongs_tos = passed.belongs_tos.map do |pbt|
+          receiver_bt = receiver_belongs_to_by_identity[pbt.identity]
+          if receiver_bt
+            pbt.comment = receiver_bt.comment if receiver_bt.comment
+            pbt.ignore = receiver_bt.ignore unless receiver_bt.ignore.nil?
+          end
+          pbt
+        end
 
         # Take each field from the freshly generated config (so structural facts
         # like `mongoid_field_name` track the model) but carry over the user's
-        # hand-edited `replace_with` masking when the field still exists.
+        # hand-edited `replace_with`/`comment`/`ignore` when the field still exists.
         receiver_field_by_name = fields.each_with_object({}) { |f, h| h[f.name] = f }
         merged.fields = passed.fields.map do |pf|
           receiver = receiver_field_by_name[pf.name]
-          pf.replace_with = receiver.replace_with if receiver&.replace_with
+          if receiver
+            pf.replace_with = receiver.replace_with if receiver.replace_with
+            pf.comment = receiver.comment if receiver.comment
+            pf.ignore = receiver.ignore unless receiver.ignore.nil?
+          end
           pf
         end
       end

--- a/lib/exwiw/mongodb_field.rb
+++ b/lib/exwiw/mongodb_field.rb
@@ -11,6 +11,11 @@ module Exwiw
     # masks/projects by `name` (the storage key) — but surfacing the accessor
     # keeps an otherwise cryptic short key understandable in the config.
     attribute :mongoid_field_name, optional(String), skip_serializing_if_nil: true
+    # User-owned fields preserved across schema regeneration (see
+    # MongodbCollectionConfig#merge). `ignore:true` drops the field from extraction
+    # once the config is loaded (see MongodbCollectionConfig#reject_ignored_members!).
+    attribute :comment, optional(String), skip_serializing_if_nil: true
+    attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     def self.from_symbol_keys(hash)
       from(hash.transform_keys(&:to_s))

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -30,7 +30,7 @@ module Exwiw
       adapter = Adapter.build(@connection_config, @logger)
       configs = load_table_config(adapter.class.table_config_class)
 
-      validate_skipped(configs)
+      validate_ignored(configs)
       validate_rails_managed_target!(configs)
 
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
@@ -52,8 +52,8 @@ module Exwiw
       ordered_table_names.each_with_index do |table_name, idx|
         table = table_by_name.fetch(table_name)
 
-        if table.skip
-          @logger.info("Skipping data extraction for '#{table_name}' (skip:true)")
+        if table.ignore
+          @logger.info("Skipping data extraction for '#{table_name}' (ignore:true)")
           next
         end
 
@@ -141,33 +141,37 @@ module Exwiw
     private def load_table_config(klass)
       Dir[File.join(@config_dir, "*.json")].map do |file|
         json = JSON.parse(File.read(file))
-        klass.from(json)
+        # Drop belongs_tos/columns(fields) flagged ignore:true so they are not
+        # considered during extraction. Done here (after loading from file)
+        # rather than in `.from` so the schema generators keep the full config
+        # and can preserve the ignored entries on regeneration.
+        klass.from(json).reject_ignored_members!
       end
     end
 
-    private def validate_skipped(configs)
-      skipped_names = configs.select { |c| c.skip }.map(&:name).to_set
-      return if skipped_names.empty?
+    private def validate_ignored(configs)
+      ignored_names = configs.select { |c| c.ignore }.map(&:name).to_set
+      return if ignored_names.empty?
 
       configs.each do |config|
-        next if config.skip
+        next if config.ignore
         next unless config.respond_to?(:belongs_tos)
 
-        dangling = config.belongs_tos.select { |rel| skipped_names.include?(rel.table_name) }
+        dangling = config.belongs_tos.select { |rel| ignored_names.include?(rel.table_name) }
         next if dangling.empty?
 
         raise ArgumentError,
-              "Table '#{config.name}' has belongs_to references to skipped table(s): " \
+              "Table '#{config.name}' has belongs_to references to ignored table(s): " \
               "#{dangling.map(&:table_name).join(', ')}. " \
-              "Remove the belongs_to entries or unset `skip` on the referenced table."
+              "Remove the belongs_to entries or unset `ignore` on the referenced table."
       end
 
-      if @dump_target.table_name && skipped_names.include?(@dump_target.table_name)
+      if @dump_target.table_name && ignored_names.include?(@dump_target.table_name)
         raise ArgumentError,
-              "--target-table '#{@dump_target.table_name}' is marked skip:true and cannot be used as a dump target."
+              "--target-table '#{@dump_target.table_name}' is marked ignore:true and cannot be used as a dump target."
       end
 
-      skipped_names.each { |n| @logger.info("Table '#{n}' is marked skip:true (schema will be included, data extraction skipped)") }
+      ignored_names.each { |n| @logger.info("Table '#{n}' is marked ignore:true (schema will be included, data extraction skipped)") }
     end
 
     private def validate_rails_managed_target!(configs)

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -80,15 +80,15 @@ module Exwiw
 
         # Tables with a composite primary key (`representative.primary_key` is an
         # Array) are not supported yet. Emit them with `primary_key` omitted,
-        # `skip: true`, and a `type` that marks them as unsupported — the `type`
+        # `ignore: true`, and a `type` that marks them as unsupported — the `type`
         # acts as a signpost for adding support later. The config file itself is
-        # still generated so a user can manually remove `skip` and wire it up when
-        # needed.
+        # still generated so a user can manually remove `ignore` and wire it up
+        # when needed.
         if primary_key.is_a?(Array)
           TableConfig.from_symbol_keys(
             name: table_name,
             type: TableConfig::UNSUPPORTED_COMPOSITE_PRIMARY_KEY,
-            skip: true,
+            ignore: true,
             comment: "exwiw does not support composite primary keys " \
                      "(#{primary_key.join(', ')}); data extraction is skipped.",
             belongs_tos: aggregate_belongs_tos(model_group),

--- a/lib/exwiw/table_column.rb
+++ b/lib/exwiw/table_column.rb
@@ -7,6 +7,11 @@ module Exwiw
     attribute :name, String
     attribute :replace_with, optional(String), skip_serializing_if_nil: true
     attribute :raw_sql, optional(String), skip_serializing_if_nil: true
+    # User-owned fields preserved across schema regeneration (see
+    # TableConfig#merge). `ignore:true` drops the column from extraction (SELECT /
+    # INSERT) once the config is loaded (see TableConfig#reject_ignored_members!).
+    attribute :comment, optional(String), skip_serializing_if_nil: true
+    attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     def self.from_symbol_keys(hash)
       from(hash.transform_keys(&:to_s))

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -12,7 +12,7 @@ module Exwiw
     ].freeze
 
     # type marking a table with a composite primary key, which exwiw does not
-    # support yet. schema:generate attaches it together with skip:true. Unlike
+    # support yet. schema:generate attaches it together with ignore:true. Unlike
     # rails-managed tables, columns/belongs_tos are retained so it can serve as a
     # signpost for adding support later.
     UNSUPPORTED_COMPOSITE_PRIMARY_KEY = "unsupported_composite_primary_key"
@@ -25,7 +25,7 @@ module Exwiw
     attribute :belongs_tos, array(BelongsTo), default: []
     attribute :columns, array(TableColumn), default: []
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
-    attribute :skip, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
+    attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
 
     def self.from(hash)
       config = super
@@ -52,6 +52,16 @@ module Exwiw
 
     def column_names
       columns.map(&:name)
+    end
+
+    # Drop the belongs_tos/columns flagged `ignore:true` so they are excluded
+    # from extraction (dependency ordering, SELECT projection, INSERT). The
+    # config files on disk keep these entries; this is applied to the runtime
+    # config right after it is loaded from a file (see Runner#load_table_config).
+    def reject_ignored_members!
+      self.belongs_tos = belongs_tos.reject(&:ignore)
+      self.columns = columns.reject(&:ignore)
+      self
     end
 
     def belongs_to(table_name)
@@ -111,9 +121,22 @@ module Exwiw
         merged_table.type = passed_table.type
         merged_table.comment = comment
         merged_table.filter = filter
-        merged_table.belongs_tos = passed_table.belongs_tos
         merged_table.bulk_insert_chunk_size = passed_table.bulk_insert_chunk_size
-        merged_table.skip = skip
+        merged_table.ignore = ignore
+
+        # Structural facts of each belongs_to come from the freshly generated
+        # config, but the user-owned `comment`/`ignore` carry over when the same
+        # relation still exists.
+        receiver_belongs_to_by_identity = belongs_tos.each_with_object({}) { |bt, hash| hash[bt.identity] = bt }
+        merged_table.belongs_tos =
+          passed_table.belongs_tos.map do |passed_belongs_to|
+            receiver_belongs_to = receiver_belongs_to_by_identity[passed_belongs_to.identity]
+            if receiver_belongs_to
+              passed_belongs_to.comment = receiver_belongs_to.comment if receiver_belongs_to.comment
+              passed_belongs_to.ignore = receiver_belongs_to.ignore unless receiver_belongs_to.ignore.nil?
+            end
+            passed_belongs_to
+          end
 
         receiver_column_by_name = columns.each_with_object({}) { |column, hash| hash[column.name] = column }
 
@@ -144,9 +167,9 @@ module Exwiw
                 "Table '#{name}' has type=#{type}; columns must not be defined."
         end
       else
-        # A skip:true table is not extracted, so primary_key is not required
+        # An ignore:true table is not extracted, so primary_key is not required
         # (e.g. a composite-primary-key table that exwiw does not support).
-        if primary_key.nil? && !skip
+        if primary_key.nil? && !ignore
           raise ArgumentError, "Table '#{name}' requires primary_key."
         end
       end

--- a/spec/explain_runner_spec.rb
+++ b/spec/explain_runner_spec.rb
@@ -85,17 +85,17 @@ module Exwiw
       end
     end
 
-    describe '#run when --target-table is marked skip:true' do
+    describe '#run when --target-table is marked ignore:true' do
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
 
       before do
         shops = JSON.parse(File.read('scenario/sqlite-schema/shops.json'))
-        shops['skip'] = true
+        shops['ignore'] = true
         File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
       end
 
       it 'raises ArgumentError' do
-        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked skip:true/)
+        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked ignore:true/)
       end
     end
   end

--- a/spec/mongodb_collection_config_spec.rb
+++ b/spec/mongodb_collection_config_spec.rb
@@ -78,21 +78,21 @@ module Exwiw
         end
       end
 
-      context 'with skip:true' do
+      context 'with ignore:true' do
         let(:json) do
           {
             "name" => "logs",
             "primary_key" => "_id",
-            "skip" => true,
+            "ignore" => true,
             "belongs_tos" => [],
             "fields" => [{ "name" => "_id" }],
           }
         end
 
-        it 'loads skip and round-trips through to_hash' do
+        it 'loads ignore and round-trips through to_hash' do
           config = described_class.from(json)
-          expect(config.skip).to eq(true)
-          expect(config.to_hash["skip"]).to eq(true)
+          expect(config.ignore).to eq(true)
+          expect(config.to_hash["ignore"]).to eq(true)
         end
       end
 
@@ -112,6 +112,63 @@ module Exwiw
           config = described_class.from(json)
           expect(config.fields.first.to_hash).to eq({ "name" => "raw" })
         end
+      end
+    end
+
+    describe '#merge' do
+      let(:current) do
+        described_class.from_symbol_keys(
+          name: 'orders',
+          primary_key: '_id',
+          belongs_tos: [{ table_name: 'shops', foreign_key: 'shop_id', comment: 'bt note', ignore: true }],
+          fields: [
+            { name: '_id' },
+            { name: 'token', comment: 'secret', ignore: true, replace_with: 'X' },
+          ],
+        )
+      end
+      let(:passed) do
+        described_class.from_symbol_keys(
+          name: 'orders',
+          primary_key: '_id',
+          belongs_tos: [{ table_name: 'shops', foreign_key: 'shop_id' }],
+          fields: [{ name: '_id' }, { name: 'token' }, { name: 'extra' }],
+        )
+      end
+
+      it 'preserves user-owned comment/ignore on belongs_tos' do
+        merged = current.merge(passed)
+        expect(merged.belongs_tos.map(&:to_hash)).to eq([
+          { 'table_name' => 'shops', 'foreign_key' => 'shop_id', 'comment' => 'bt note', 'ignore' => true },
+        ])
+      end
+
+      it 'preserves user-owned comment/ignore/replace_with on fields while tracking added fields' do
+        merged = current.merge(passed)
+        token = merged.fields.find { |f| f.name == 'token' }
+        expect(token.to_hash).to eq({ 'name' => 'token', 'replace_with' => 'X', 'comment' => 'secret', 'ignore' => true })
+        expect(merged.fields.map(&:name)).to eq(['_id', 'token', 'extra'])
+      end
+    end
+
+    describe '#reject_ignored_members!' do
+      let(:config) do
+        described_class.from_symbol_keys(
+          name: 'orders',
+          primary_key: '_id',
+          belongs_tos: [{ table_name: 'shops', foreign_key: 'shop_id', ignore: true }],
+          fields: [{ name: '_id' }, { name: 'token', ignore: true }],
+        )
+      end
+
+      it 'drops belongs_tos and fields flagged ignore:true' do
+        config.reject_ignored_members!
+        expect(config.belongs_tos).to eq([])
+        expect(config.fields.map(&:name)).to eq(['_id'])
+      end
+
+      it 'returns self so it can be chained after load' do
+        expect(config.reject_ignored_members!).to be(config)
       end
     end
 

--- a/spec/mongoid_schema_generator_spec.rb
+++ b/spec/mongoid_schema_generator_spec.rb
@@ -310,12 +310,12 @@ module Exwiw
         expect(result["fields"].map { |f| f["name"] }).to include("name", "shop_id")
       end
 
-      it "preserves a user-customized skip flag across regeneration" do
+      it "preserves a user-customized ignore flag across regeneration" do
         path = File.join(output_dir, "system_announcements.json")
         existing = {
           "name" => "system_announcements",
           "primary_key" => "_id",
-          "skip" => true,
+          "ignore" => true,
           "belongs_tos" => [],
           "fields" => [{ "name" => "_id" }],
         }
@@ -323,7 +323,7 @@ module Exwiw
 
         described_class.new(models: [MongoidDummy::SystemAnnouncement], output_dir: output_dir).generate!
 
-        expect(JSON.parse(File.read(path))["skip"]).to eq(true)
+        expect(JSON.parse(File.read(path))["ignore"]).to eq(true)
       end
 
       it "preserves an embedded config's masking and embedded_in across regeneration" do
@@ -368,7 +368,7 @@ module Exwiw
       end
 
       it "preserves bulk_insert_chunk_size and drops fields no longer on the model across regeneration" do
-        # The full regeneration contract beyond replace_with/skip: a
+        # The full regeneration contract beyond replace_with/ignore: a
         # user-tuned `bulk_insert_chunk_size` survives, while the field list
         # tracks the model — a field that no longer exists on the model is
         # dropped (not retained as a stale entry) even if it carried a

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -209,18 +209,18 @@ module Exwiw
       end
     end
 
-    describe 'with skip:true on a table config' do
+    describe 'with ignore:true on a table config' do
       let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
 
       before do
         FileUtils.cp('scenario/sqlite-schema/shops.json', File.join(config_dir, 'shops.json'))
 
         announcements = JSON.parse(File.read('scenario/sqlite-schema/system_announcements.json'))
-        announcements['skip'] = true
+        announcements['ignore'] = true
         File.write(File.join(config_dir, 'system_announcements.json'), JSON.dump(announcements))
       end
 
-      it 'emits schema for the skipped table but no insert/delete files' do
+      it 'emits schema for the ignored table but no insert/delete files' do
         runner.run
 
         expect(Dir[File.join(output_dir, 'insert-*-system_announcements.sql')]).to be_empty
@@ -231,39 +231,39 @@ module Exwiw
         expect(File.read(schema_file)).to include('system_announcements')
       end
 
-      it 'still emits files for non-skipped tables' do
+      it 'still emits files for non-ignored tables' do
         runner.run
 
         expect(Dir[File.join(output_dir, 'insert-*-shops.sql')]).not_to be_empty
       end
     end
 
-    describe 'when a non-skipped table has belongs_to a skipped table' do
+    describe 'when a non-ignored table has belongs_to an ignored table' do
       let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
 
       before do
         shops = JSON.parse(File.read('scenario/sqlite-schema/shops.json'))
-        shops['skip'] = true
+        shops['ignore'] = true
         File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
         FileUtils.cp('scenario/sqlite-schema/users.json', File.join(config_dir, 'users.json'))
       end
 
       it 'raises ArgumentError with a clear message' do
-        expect { runner.run }.to raise_error(ArgumentError, /belongs_to references to skipped table\(s\): shops/)
+        expect { runner.run }.to raise_error(ArgumentError, /belongs_to references to ignored table\(s\): shops/)
       end
     end
 
-    describe 'when --target-table is skipped' do
+    describe 'when --target-table is ignored' do
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
 
       before do
         shops = JSON.parse(File.read('scenario/sqlite-schema/shops.json'))
-        shops['skip'] = true
+        shops['ignore'] = true
         File.write(File.join(config_dir, 'shops.json'), JSON.dump(shops))
       end
 
       it 'raises ArgumentError' do
-        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked skip:true/)
+        expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked ignore:true/)
       end
     end
 

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -39,7 +39,7 @@ module Exwiw
 
     # Composite primary key model. `representative.primary_key` returns an Array
     # for these, which exwiw does not support; the generator must mark them
-    # skip:true instead of raising on the TableConfig type check.
+    # ignore:true instead of raising on the TableConfig type check.
     class CompositePkRecord < ::ActiveRecord::Base
       self.table_name = "composite_pk_records"
       self.primary_key = [:organization_id, :location_id]
@@ -231,8 +231,8 @@ module Exwiw
           .find { |t| t.name == "composite_pk_records" }
       end
 
-      it "emits the table with skip:true and no primary_key" do
-        expect(table.skip).to eq(true)
+      it "emits the table with ignore:true and no primary_key" do
+        expect(table.ignore).to eq(true)
         expect(table.primary_key).to be_nil
       end
 

--- a/spec/table_config_spec.rb
+++ b/spec/table_config_spec.rb
@@ -121,19 +121,19 @@ module Exwiw
         end
       end
 
-      context 'when receiver has skip:true' do
+      context 'when receiver has ignore:true' do
         let(:current_config) do
           TableConfig.from_symbol_keys(
             name: 'users',
             primary_key: 'id',
-            skip: true,
+            ignore: true,
             belongs_tos: current_belongs_tos,
             columns: current_columns,
           )
         end
 
-        it 'preserves skip from the receiver in the merged config' do
-          expect(merged_config.skip).to eq(true)
+        it 'preserves ignore from the receiver in the merged config' do
+          expect(merged_config.ignore).to eq(true)
         end
       end
 
@@ -150,6 +150,39 @@ module Exwiw
           expect(actual.map(&:to_hash)).to eq([
             { 'name' => 'id' },
             { 'name' => 'name', 'replace_with' => 'MaskedName{id}' },
+          ])
+        end
+      end
+
+      context 'when belongs_to has user-owned comment/ignore' do
+        let(:current_belongs_tos) do
+          [{ table_name: 'clients', foreign_key: 'company_id', comment: 'hand-written', ignore: true }]
+        end
+        let(:passed_belongs_tos) do
+          [{ table_name: 'clients', foreign_key: 'company_id' }]
+        end
+
+        it 'preserves comment/ignore from receiver while keeping the relation' do
+          actual = merged_config.belongs_tos
+          expect(actual.map(&:to_hash)).to eq([
+            { 'table_name' => 'clients', 'foreign_key' => 'company_id', 'comment' => 'hand-written', 'ignore' => true },
+          ])
+        end
+      end
+
+      context 'when columns have user-owned comment/ignore' do
+        let(:current_columns) do
+          [{ name: 'id' }, { name: 'secret', comment: 'PII', ignore: true }]
+        end
+        let(:passed_columns) do
+          [{ name: 'id' }, { name: 'secret' }]
+        end
+
+        it 'preserves comment/ignore from receiver' do
+          actual = merged_config.columns
+          expect(actual.map(&:to_hash)).to eq([
+            { 'name' => 'id' },
+            { 'name' => 'secret', 'comment' => 'PII', 'ignore' => true },
           ])
         end
       end
@@ -182,6 +215,34 @@ module Exwiw
         it 'preserves comment from receiver (user-owned)' do
           expect(merged_config.comment).to eq('localized comment')
         end
+      end
+    end
+
+    describe '#reject_ignored_members!' do
+      let(:config) do
+        TableConfig.from_symbol_keys(
+          name: 'orders',
+          primary_key: 'id',
+          belongs_tos: [
+            { table_name: 'shops', foreign_key: 'shop_id' },
+            { table_name: 'users', foreign_key: 'user_id', ignore: true },
+          ],
+          columns: [
+            { name: 'id' },
+            { name: 'secret', ignore: true },
+            { name: 'amount' },
+          ],
+        )
+      end
+
+      it 'drops belongs_tos and columns flagged ignore:true' do
+        config.reject_ignored_members!
+        expect(config.belongs_tos.map(&:table_name)).to eq(['shops'])
+        expect(config.column_names).to eq(['id', 'amount'])
+      end
+
+      it 'returns self so it can be chained after load' do
+        expect(config.reject_ignored_members!).to be(config)
       end
     end
 


### PR DESCRIPTION
## 概要

`belongs_to` / `columns`（MongoDBは `fields`）に、人手で編集でき再生成で上書きされない以下のキーを追加しました。

- `comment` — 自由記述のメモ（exwiw は読まない、純粋に情報用）
- `ignore: true` — そのエントリを抽出対象から除外

あわせて、トップレベルの設定属性 `skip` を `ignore` にリネームしました（**破壊的変更・互換エイリアスなし**）。

## 挙動

- `ignore: true` の belongs_to / column / field は、**設定ファイル読み込み直後に除去**され、依存順序解決・SELECT・INSERT から外れます。除去は実行時のみで、ディスク上のJSONには残ります。
  - column/field を ignore してもターゲットのDDLには列が残り（DDLはソースDB由来）、データだけコピーされません。
  - belongs_to を ignore するとその関連は辿られません。
- `comment` / `ignore` は `exwiw:schema:generate` / `exwiw:mongoid:schema:generate` の再生成でユーザー編集値が保持されます（`replace_with` と同様）。belongs_to は構造はジェネレータ生成版、`comment`/`ignore` はユーザー版を引き継ぎます。
- トップレベルの `skip` → `ignore` リネームに伴い、ライブラリの `TableConfig#skip` / `MongodbCollectionConfig#skip` も `#ignore` に変更。composite PK テーブルのジェネレータ出力も `ignore: true` になります。

> ⚠️ **破壊的変更**: 既存の設定ファイルで `"skip": true` を使っているものは `"ignore": true` への置換が必要です。

## テスト

- 関連ユニットspec（table_config / mongodb_collection_config / runner / explain_runner / schema_generator / mongoid_schema_generator）は全パス。
- 全スイートで残る mysql_adapter 実行系・insert スナップショットの失敗は、トリロジードライバの値フォーマット差による**既存の環境依存failure**であり、本PRの変更前 `main` でも同一に発生することを確認済み（本PRによる回帰ではない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)