### PR TITLE
fix(mysql): binaryカラムのUTF-8値でexport時にエンコーディングエラーになる問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MySQL export no longer crashes with `IO#write: "\xE4" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)` when a value comes from a binary-collation / `VARBINARY` / `BLOB` column but holds UTF-8 text (e.g. Japanese). Both the `mysql2` and `trilogy` drivers tag such values as `ASCII-8BIT`; writing them to the UTF-8 INSERT file failed inside host processes whose `Encoding.default_internal` is UTF-8 (a Rails app, or `RUBYOPT=-EUTF-8`). The driver-returned strings are now re-tagged UTF-8 (bytes unchanged) so the write is a no-op conversion.
+
 ## [0.3.4] - 2026-05-31
 
 ### Changed

--- a/lib/exwiw/adapter/mysql_client.rb
+++ b/lib/exwiw/adapter/mysql_client.rb
@@ -57,7 +57,7 @@ module Exwiw
       def self.stringify_value(value)
         case value
         when nil then nil
-        when String then value
+        when String then normalize_encoding(value)
         when Time
           # Emit fractional seconds only when present. A Time can't tell us the
           # column's declared precision, so a zero fraction on a DATETIME(6)
@@ -76,6 +76,21 @@ module Exwiw
         end
       end
 
+      # Re-tag a value string as UTF-8 when it comes back as ASCII-8BIT (BINARY).
+      # Both drivers tag values from binary-collation / VARBINARY / BLOB columns
+      # as ASCII-8BIT even when the bytes are really UTF-8 text. When exwiw runs
+      # inside a host process whose Encoding.default_internal is UTF-8 (e.g. a
+      # Rails app, or RUBYOPT=-EUTF-8), IO#write enables conversion, so writing
+      # such a binary string carrying multi-byte bytes (e.g. Japanese "\xE4...")
+      # to the INSERT file raises "\xE4 from ASCII-8BIT to UTF-8"
+      # (Encoding::UndefinedConversionError). Re-tagging makes that write a
+      # UTF-8 -> UTF-8 no-op; only the tag changes, the bytes pass through.
+      def self.normalize_encoding(str)
+        return str unless str.encoding == Encoding::ASCII_8BIT
+
+        str.dup.force_encoding(Encoding::UTF_8)
+      end
+
       attr_reader :driver
 
       # `driver:` is mainly a test seam to force a specific driver; in normal use
@@ -92,7 +107,8 @@ module Exwiw
         case @driver
         when :mysql2
           res = raw.query(sql, cast: false, as: :array)
-          Result.new(res.fields, res.to_a)
+          rows = res.to_a.map { |row| row.map { |value| self.class.stringify_value(value) } }
+          Result.new(res.fields, rows)
         when :trilogy
           res = raw.query(sql)
           rows = res.rows.map { |row| row.map { |value| self.class.stringify_value(value) } }

--- a/spec/adapter/mysql_client_spec.rb
+++ b/spec/adapter/mysql_client_spec.rb
@@ -11,6 +11,23 @@ module Exwiw
           expect(MysqlClient.stringify_value('hello')).to eq('hello')
         end
 
+        it 're-tags ASCII-8BIT strings (binary-collation columns) as UTF-8 without changing bytes' do
+          utf8_bytes = 'あ'.encode('UTF-8')
+          binary = utf8_bytes.dup.force_encoding(Encoding::ASCII_8BIT)
+
+          result = MysqlClient.stringify_value(binary)
+
+          expect(result.encoding).to eq(Encoding::UTF_8)
+          expect(result.bytes).to eq(utf8_bytes.bytes)
+          # The generated INSERT is written to a UTF-8 file, so this must not raise.
+          expect { +'' << result }.not_to raise_error
+        end
+
+        it 'leaves already-UTF-8 strings untouched' do
+          str = 'すでにUTF-8'
+          expect(MysqlClient.stringify_value(str).encoding).to eq(Encoding::UTF_8)
+        end
+
         it 'renders numbers as their literal text' do
           expect(MysqlClient.stringify_value(42)).to eq('42')
           expect(MysqlClient.stringify_value(BigDecimal('0.123e1'))).to eq('1.23')


### PR DESCRIPTION
## 概要

MySQL の `export` で、binary collation / `VARBINARY` / `BLOB` カラムの値が UTF-8 テキスト（日本語など）を保持しているときに発生していたエンコーディングエラーを修正します。

```
runner.rb:90:in 'IO#write': "\xE4" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
```

## 原因

- `mysql2` / `trilogy` どちらのドライバも、binary系カラムの値を中身がUTF-8テキストでも **`ASCII-8BIT`** タグで返す。
- exwiw が **`Encoding.default_internal` が UTF-8 のホストプロセス**（Rails アプリ、または `RUBYOPT=-EUTF-8`）の中で動くと、`File.open(path, 'w')` への `IO#write` が変換を有効化し、`ASCII-8BIT → UTF-8` のトランスコードを試みて `\xE4` で落ちる。
- Ruby 本体のバージョン差ではなく、`default_internal` の有無が引き金（Rails アプリ配下で `bundle exec` した場合に再現）。

## 修正

- `MysqlClient.normalize_encoding` を追加し、ドライバが返した `ASCII-8BIT` の文字列値を **バイト列はそのままに UTF-8 タグへ付け替え**る。これで書き込みが UTF-8 → UTF-8 の no-op になり例外が出ない。
- `trilogy` 経路に加え、同じ問題を持つ `mysql2`（`cast: false`）経路も同じ正規化を通すよう統一。

## テスト

- `spec/adapter/mysql_client_spec.rb` に回帰テストを追加（ASCII-8BIT → UTF-8 への再タグ付け / バイト列保持 / UTF-8 はそのまま）。
- Ruby 3.4.8・`Encoding.default_internal = UTF-8` の条件で書き込みが成功することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)