### PR TITLE
feat(runner): export失敗時に原因の抽出クエリを出力

### DIFF
--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -139,6 +139,23 @@ module Exwiw
       def commented_sql(query_ast)
         "#{sql_query_comment(query_ast)} #{compile_ast(query_ast)}"
       end
+
+      # One-line, human-readable description of the extraction query, used by the
+      # Runner in error messages so a failure during INSERT/COPY generation (or
+      # query execution) can be traced back to the query that produced the data.
+      # SQL adapters expose the compiled, comment-prefixed SELECT; non-SQL
+      # adapters (e.g. MongodbAdapter) override or fall back to the query object's
+      # own inspect output. Best-effort: never raise from here, since it runs on
+      # an error path.
+      def describe_query(query_ast)
+        if respond_to?(:compile_ast)
+          commented_sql(query_ast)
+        else
+          query_ast.inspect
+        end
+      rescue => e
+        "<unavailable: #{e.class}: #{e.message}>"
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mongodb_adapter.rb
+++ b/lib/exwiw/adapter/mongodb_adapter.rb
@@ -120,6 +120,12 @@ module Exwiw
         raise NotImplementedError, "MongodbAdapter does not support explain yet"
       end
 
+      def describe_query(query)
+        "find collection=#{query.collection} filter=#{query.filter.inspect} projection=#{query.projection.inspect}"
+      rescue => e
+        "<unavailable: #{e.class}: #{e.message}>"
+      end
+
       def output_extension
         'jsonl'
       end

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -60,51 +60,67 @@ module Exwiw
         @logger.info("Processing table '#{table_name}'... (#{idx + 1}/#{total_size})")
 
         query_ast = adapter.build_query(table, @dump_target, table_by_name)
-        results = adapter.execute(query_ast)
-        record_num = results.size
 
-        if record_num.zero?
-          @logger.info("  No records matched. skip this table.")
-          next
-        end
-        insert_idx = (idx + 1).to_s.rjust(3, '0')
+        # Track which phase we are in so that, if an error is raised while
+        # turning the fetched rows into SQL/JSONL, the rescue below can report
+        # both the failing step and the exact extraction query that produced the
+        # data being processed.
+        phase = "executing extraction query"
+        begin
+          results = adapter.execute(query_ast)
+          record_num = results.size
 
-        if @output_format == 'copy'
-          @logger.debug("  Generate COPY statement...")
-          copy_sql = adapter.to_copy_from_stdin(results, table)
-          @logger.info("  Generated COPY statement for #{record_num} records.")
-
-          File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
-            file.puts(copy_sql)
-            post = adapter.post_insert_sql(table)
-            file.puts(post) if post
+          if record_num.zero?
+            @logger.info("  No records matched. skip this table.")
+            next
           end
-        else
-          @logger.debug("  Generate INSERT statement...")
-          chunk_size = table.bulk_insert_chunk_size
-          chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
-          insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
+          insert_idx = (idx + 1).to_s.rjust(3, '0')
 
-          @logger.info("  Generated INSERT statement for #{record_num} records (#{chunks.size} statement(s)).")
-          File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
-            file.puts(insert_sql)
-            post = adapter.post_insert_sql(table)
-            file.puts(post) if post
-          end
-        end
+          if @output_format == 'copy'
+            phase = "generating COPY statement"
+            @logger.debug("  Generate COPY statement...")
+            copy_sql = adapter.to_copy_from_stdin(results, table)
+            @logger.info("  Generated COPY statement for #{record_num} records.")
 
-        if adapter.supports_bulk_delete? && !@insert_only && !(table.respond_to?(:rails_managed?) && table.rails_managed?)
-          @logger.debug("  Generate DELETE statement...")
-          delete_sql = adapter.to_bulk_delete(query_ast, table)
-          if @logger.debug?
-            @logger.debug("  Generated DELETE statement:\n#{delete_sql}")
+            File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+              file.puts(copy_sql)
+              post = adapter.post_insert_sql(table)
+              file.puts(post) if post
+            end
           else
-            @logger.info("  Generated DELETE statement.")
+            phase = "generating INSERT statement"
+            @logger.debug("  Generate INSERT statement...")
+            chunk_size = table.bulk_insert_chunk_size
+            chunks = chunk_size ? results.each_slice(chunk_size).to_a : [results]
+            insert_sql = chunks.map { |chunk_rows| adapter.to_bulk_insert(chunk_rows, table) }.join("\n")
+
+            @logger.info("  Generated INSERT statement for #{record_num} records (#{chunks.size} statement(s)).")
+            File.open(File.join(@output_dir, "insert-#{insert_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+              file.puts(insert_sql)
+              post = adapter.post_insert_sql(table)
+              file.puts(post) if post
+            end
           end
-          delete_idx = (total_size - idx).to_s.rjust(3, '0')
-          File.open(File.join(@output_dir, "delete-#{delete_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
-            file.puts(delete_sql)
+
+          if adapter.supports_bulk_delete? && !@insert_only && !(table.respond_to?(:rails_managed?) && table.rails_managed?)
+            phase = "generating DELETE statement"
+            @logger.debug("  Generate DELETE statement...")
+            delete_sql = adapter.to_bulk_delete(query_ast, table)
+            if @logger.debug?
+              @logger.debug("  Generated DELETE statement:\n#{delete_sql}")
+            else
+              @logger.info("  Generated DELETE statement.")
+            end
+            delete_idx = (total_size - idx).to_s.rjust(3, '0')
+            File.open(File.join(@output_dir, "delete-#{delete_idx}-#{table_name}.#{adapter.output_extension}"), 'w') do |file|
+              file.puts(delete_sql)
+            end
           end
+        rescue => e
+          @logger.error("Error while #{phase} for table '#{table_name}' (#{idx + 1}/#{total_size}): #{e.class}: #{e.message}")
+          @logger.error("  Extraction query that produced the data being processed:")
+          @logger.error("    #{adapter.describe_query(query_ast)}")
+          raise
         end
       end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'fileutils'
 require 'json'
 require 'tmpdir'
+require 'stringio'
 
 module Exwiw
   RSpec.describe Runner do
@@ -122,6 +123,33 @@ module Exwiw
         expect(sql.scan(/INSERT INTO shops/).size).to eq(1)
       end
     end
+    describe 'error reporting when SQL generation fails' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2']) }
+      let(:log_io) { StringIO.new }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: 'scenario/sqlite-schema',
+          dump_target: dump_target,
+          logger: ::Logger.new(log_io),
+        )
+      end
+
+      it 're-raises and logs the table, phase, and extraction query that produced the failing data' do
+        allow_any_instance_of(Adapter::SqliteAdapter)
+          .to receive(:to_bulk_insert)
+          .and_raise(RuntimeError, 'simulated encoding error in row data')
+
+        expect { runner.run }.to raise_error(RuntimeError, 'simulated encoding error in row data')
+
+        log = log_io.string
+        expect(log).to include("Error while generating INSERT statement for table 'shops'")
+        expect(log).to include('Extraction query that produced the data being processed:')
+        expect(log).to match(/SELECT .+ FROM shops WHERE shops\.id IN \('1', '2'\)/)
+      end
+    end
+
     describe 'dump-all mode (no target table or ids)' do
       let(:dump_target) { DumpTarget.new(table_name: nil, ids: []) }
       let(:runner) do


### PR DESCRIPTION
## 概要

export中にSQL/JSONL生成（`to_bulk_insert` / `to_copy_from_stdin`）や実行（`execute`）でエラーが発生した際、**どのテーブルの・どの抽出クエリ(SELECT)で取ったデータを・どのフェーズでSQL化していて落ちたのか** をERRORログに出力するようにした。

従来は抽出SELECTが `debug` レベルでしか出力されず、デフォルトの `info` 運用ではエラー時に原因クエリを追跡できなかった。

## 変更内容

- `lib/exwiw/runner.rb`: テーブル処理を `begin/rescue` で囲み、`phase`（取得 / INSERT生成 / COPY生成 / DELETE生成）を追跡。エラー時にテーブル名・フェーズ・抽出クエリをERRORログ出力してから元の例外を再raise。
- `lib/exwiw/adapter.rb`: 抽出クエリを文字列化する `describe_query` を追加（SQLアダプタはコメント付きSELECT、フォールバックは `inspect`）。エラー経路で呼ばれるため内部例外を握りつぶすbest-effort実装。
- `lib/exwiw/adapter/mongodb_adapter.rb`: mongodb向けに `find`（collection/filter/projection）を返す `describe_query` を追加。
- `spec/runner_spec.rb`: SQL化失敗時にテーブル名・フェーズ・抽出クエリがログされ、例外が再raiseされることを検証するテストを追加。

## 出力例

\`\`\`
ERROR -- : Error while generating INSERT statement for table 'shops' (1/8): RuntimeError: ...
ERROR -- :   Extraction query that produced the data being processed:
ERROR -- :     /* exwiw table=shops */ SELECT shops.id, ... FROM shops WHERE shops.id IN ('1', '2')
\`\`\`

## 動作確認

- 本番コードパスと同等のスタンドアロン検証（sqlite + `to_bulk_insert` を意図的に失敗させる）で、上記ログ出力と例外の再raiseを確認済み。
- フルspecスイートは MySQL 9.x + mysql2 のブートストラップ接続失敗（既存の環境問題、本変更とは無関係）によりローカルで起動できず、追加specの自動実行は未実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)