### PR TITLE
fix(table_config): 抽出対象テーブルの実効columnsが空ならエラーにする

### DIFF
--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -61,6 +61,20 @@ module Exwiw
     def reject_ignored_members!
       self.belongs_tos = belongs_tos.reject(&:ignore)
       self.columns = columns.reject(&:ignore)
+
+      # A table that will be extracted needs at least one effective column;
+      # otherwise the generated SELECT (`SELECT  FROM ...`) and INSERT
+      # (`INSERT INTO t () ...`) are syntactically broken. Checked here, after
+      # rejection, so it catches both a genuinely empty `columns: []` and a list
+      # left empty because every column was ignore:true. Schema generation does
+      # not call this method, so regenerating a broken config still works.
+      if !rails_managed? && !ignore && columns.empty?
+        raise ArgumentError,
+              "Table '#{name}' has no columns to extract " \
+              "(it may be empty in the config or have all columns set to ignore:true); " \
+              "define or unignore at least one column."
+      end
+
       self
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -198,6 +198,35 @@ module Exwiw
       end
     end
 
+    describe 'when the extraction query matches zero rows' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['999999']) }
+      let(:log_io) { StringIO.new }
+      let(:runner) do
+        Runner.new(
+          connection_config: connection_config,
+          output_dir: output_dir,
+          config_dir: config_dir,
+          dump_target: dump_target,
+          logger: ::Logger.new(log_io),
+        )
+      end
+
+      before do
+        FileUtils.cp('scenario/sqlite-schema/shops.json', File.join(config_dir, 'shops.json'))
+      end
+
+      # Regression guard for runner.rb's `record_num.zero?` short-circuit: a
+      # zero-row table must be skipped entirely rather than fed to
+      # to_bulk_insert, which would otherwise emit broken `INSERT ... VALUES ;`.
+      it 'skips the table without emitting insert or delete files' do
+        expect { runner.run }.not_to raise_error
+
+        expect(Dir[File.join(output_dir, 'insert-*-shops.sql')]).to be_empty
+        expect(Dir[File.join(output_dir, 'delete-*-shops.sql')]).to be_empty
+        expect(log_io.string).to include('No records matched. skip this table.')
+      end
+    end
+
     describe 'with after_insert_hook_path (.rb)' do
       let(:hook_path) { 'tmp/runner_spec_after_hook.rb' }
       let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1', '2']) }
@@ -344,6 +373,16 @@ module Exwiw
 
         delete_files = Dir[File.join(output_dir, 'delete-*.sql')]
         expect(delete_files).not_to be_empty
+      end
+
+      context 'when the extraction query matches zero rows' do
+        let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['999999']) }
+
+        it 'skips the table without emitting a COPY file' do
+          expect { runner.run }.not_to raise_error
+
+          expect(Dir[File.join(output_dir, 'insert-*-shops.sql')]).to be_empty
+        end
       end
     end
   end

--- a/spec/table_config_spec.rb
+++ b/spec/table_config_spec.rb
@@ -311,6 +311,42 @@ module Exwiw
             )
           }.to raise_error(ArgumentError, /requires primary_key/)
         end
+
+        # Empty columns only become a problem at extraction time, which always
+        # runs reject_ignored_members! first (see Runner#load_table_config), so
+        # the guard lives there rather than at load.
+        it 'loads with empty columns but raises once reject_ignored_members! runs' do
+          config = TableConfig.from_symbol_keys(
+            name: 'users',
+            primary_key: 'id',
+            belongs_tos: [],
+            columns: [],
+          )
+          expect { config.reject_ignored_members! }.to raise_error(ArgumentError, /has no columns to extract/)
+        end
+
+        # The case that matters most: columns exist in the config but every one
+        # is ignore:true, so rejection empties them and extraction would emit
+        # broken SQL. This must raise too.
+        it 'raises from reject_ignored_members! when all columns are ignore:true' do
+          config = TableConfig.from_symbol_keys(
+            name: 'users',
+            primary_key: 'id',
+            belongs_tos: [],
+            columns: [{ name: 'secret', ignore: true }],
+          )
+          expect { config.reject_ignored_members! }.to raise_error(ArgumentError, /has no columns to extract/)
+        end
+
+        it 'does not raise when an ignore:true table has empty columns (never extracted)' do
+          config = TableConfig.from_symbol_keys(
+            name: 'users',
+            ignore: true,
+            belongs_tos: [],
+            columns: [],
+          )
+          expect { config.reject_ignored_members! }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
## 概要

抽出対象テーブルで、ignore除外後の実効columnsが空になるケースが、壊れたSQL（`SELECT  FROM ...` / `INSERT INTO t () VALUES ...`）を生成してしまう問題を修正する。

### 背景
- `columns` が空のまま抽出に進むと、SELECT句・INSERT列リストが空になり、実行時に謎のSQL構文エラー（例: `near "FROM": syntax error`）で落ちていた。
- 空になる経路は2つ:
  1. config が素で `"columns": []`
  2. 全カラムが `ignore:true` で、`reject_ignored_members!` の結果として空になる

### 修正
- `reject_ignored_members!`（ignore除外後の実効columnsが確定する場所）でチェックし、非rails-managed かつ非ignore かつ columns空なら明確なメッセージで `ArgumentError` を投げる。
  - reject後に置くことで上記2ケースの両方を捕捉する。
  - スキーマ再生成（`schema_generator` の `.from(...).merge(...)`）は `reject_ignored_members!` を通らないため、壊れた既存configの修復は引き続き可能。

### テスト
- `table_config_spec`: 素で空 / 全ignore:true / ignore:trueテーブル（抽出されないので許容）の3ケースを追加。
- `runner_spec`: 抽出クエリが0行マッチのときテーブルがスキップされ INSERT/COPY ファイルが生成されないことの回帰テストを追加（INSERT・COPY両モード）。

### 確認
- 全スイート 336 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)