### PR TITLE
feat: ActiveStorage のエクスポート対応を完成させる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- ActiveStorage support is now complete. `schema:generate` follows `has_one_attached` / `has_many_attached` macros so `active_storage_attachments` is extracted correctly via its polymorphic `belongs_to`. `active_storage_blobs` is no longer dumped wholesale: a reverse "referenced_by" extraction (a `SELECT` subquery) narrows it to only the blobs referenced by the extracted attachments. `active_storage_variant_records` (derivative, regenerable variant-tracking rows) is now emitted with `ignore: true` instead of being dumped in full — it has no path to a dump target and its `blob_id` could otherwise reference blobs outside the narrowed set, causing a foreign-key violation on import. It is also dropped from the attachments `record` polymorphic expansion so the non-ignored attachments table carries no dangling belongs_to to it. ([#69](https://github.com/heyinc/exwiw/pull/69))
+
 ## [0.3.7] - 2026-06-01
 
 - bug fix https://github.com/heyinc/exwiw/pull/67

--- a/README.md
+++ b/README.md
@@ -341,6 +341,24 @@ WHERE reviews.reviewable_id IN (/* products subquery */)
 
 The same type filter is applied on the join path — and in the matching `delete-*.sql` bulk-delete subquery — when the polymorphic table is an intermediate hop rather than the directly-dumped table.
 
+### ActiveStorage (`has_one_attached` / `has_many_attached`)
+
+ActiveStorage is handled automatically — no ActiveStorage-specific configuration is required. The `has_one_attached` / `has_many_attached` macros don't add a column to the owning model; they generate ordinary associations that exwiw already understands:
+
+- **`active_storage_attachments`** is the polymorphic join row (`belongs_to :record, polymorphic: true` + `belongs_to :blob`). `exwiw:schema:generate` expands the polymorphic `record` into one `belongs_to` per model that declared `has_*_attached` (found via the generated `has_* ..., as: :record` reflections), exactly like any other [polymorphic `belongs_to`](#polymorphic-belongs_to). So only the attachments whose owner is among the dumped rows are extracted.
+- **`active_storage_blobs`** has no `belongs_to` of its own (attachments point *at* it), so it has no path to the dump target. exwiw narrows it via **reverse / "referenced_by" extraction**: a parent table referenced by exactly one constrained, non-polymorphic child is constrained to just the referenced ids instead of dumping every row:
+
+  ```sql
+  SELECT active_storage_blobs.* FROM active_storage_blobs
+  WHERE active_storage_blobs.id IN (
+    SELECT active_storage_attachments.blob_id FROM active_storage_attachments
+    WHERE active_storage_attachments.record_id IN (/* owner subquery */)
+      AND active_storage_attachments.record_type = '...'
+  )
+  ```
+
+  `active_storage_variant_records` also references blobs, but since it has no path of its own to the dump target it doesn't constrain anything and is ignored as a referencer — blobs stays narrowed to the attachment-referenced ids. (A parent referenced by *multiple* constrained children currently falls back to dumping all of its rows.)
+
 ### Rails-managed tables (special `type` values)
 
 Some tables are owned by Rails itself rather than the application — they have no ActiveRecord model and Rails reserves the right to evolve their column shape between versions (e.g. `schema_migrations`, `ar_internal_metadata`). exwiw treats them as a distinct category via the `type` field on a table config:

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ ActiveStorage is handled automatically — no ActiveStorage-specific configurati
   ```
 
   `active_storage_variant_records` also references blobs, but since it has no path of its own to the dump target it doesn't constrain anything and is ignored as a referencer — blobs stays narrowed to the attachment-referenced ids. (A parent referenced by *multiple* constrained children currently falls back to dumping all of its rows.)
+- **`active_storage_variant_records`** holds derivative variant-tracking rows that ActiveStorage regenerates lazily, and it too has no path to the dump target — left alone it would land in the "no relation → dump all" branch and, worse, its `blob_id` could point at blobs outside the narrowed set above (a foreign-key violation on import). `exwiw:schema:generate` therefore emits it with **`ignore: true`** (and drops it from the attachments `record` polymorphic expansion so nothing carries a dangling reference to it), so its data is skipped while the DDL is still written. Remove `ignore` from the generated config if you really need to export it.
 
 ### Rails-managed tables (special `type` values)
 

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -226,6 +226,10 @@ module Exwiw
       end
 
       private def compile_subquery(subquery)
+        # A SelectSubquery wraps a full Select (the referencing table's
+        # extraction query, projected to a foreign key); compile it as-is.
+        return compile_ast(subquery.query) if subquery.is_a?(Exwiw::QueryAst::SelectSubquery)
+
         inner_values = subquery.where_values.map { |v| escape_value(v) }
         "SELECT #{subquery.table_name}.#{subquery.select_column} " \
           "FROM #{subquery.table_name} " \

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -253,6 +253,10 @@ module Exwiw
       end
 
       private def compile_subquery(subquery)
+        # A SelectSubquery wraps a full Select (the referencing table's
+        # extraction query, projected to a foreign key); compile it as-is.
+        return compile_ast(subquery.query) if subquery.is_a?(Exwiw::QueryAst::SelectSubquery)
+
         inner_values = subquery.where_values.map { |v| escape_value(v) }
         "SELECT #{subquery.table_name}.#{subquery.select_column} " \
           "FROM #{subquery.table_name} " \

--- a/lib/exwiw/adapter/sqlite_adapter.rb
+++ b/lib/exwiw/adapter/sqlite_adapter.rb
@@ -198,6 +198,10 @@ module Exwiw
       end
 
       private def compile_subquery(subquery)
+        # A SelectSubquery wraps a full Select (the referencing table's
+        # extraction query, projected to a foreign key); compile it as-is.
+        return compile_ast(subquery.query) if subquery.is_a?(Exwiw::QueryAst::SelectSubquery)
+
         inner_values = subquery.where_values.map { |v| escape_value(v) }
         "SELECT #{subquery.table_name}.#{subquery.select_column} " \
           "FROM #{subquery.table_name} " \

--- a/lib/exwiw/query_ast.rb
+++ b/lib/exwiw/query_ast.rb
@@ -41,7 +41,7 @@ module Exwiw
         {
           column_name: column_name,
           operator: operator,
-          value: value.is_a?(Subquery) ? value.to_h : value,
+          value: value.is_a?(Subquery) || value.is_a?(SelectSubquery) ? value.to_h : value,
         }
       end
     end
@@ -62,6 +62,24 @@ module Exwiw
           where_column: where_column,
           where_values: where_values,
         }
+      end
+    end
+
+    # A subquery whose body is a full `Select`, projected down to a single
+    # column. Unlike the flat `Subquery` above (one column = one IN-list), this
+    # carries the referencing table's complete extraction query — joins,
+    # multiple where conditions, polymorphic type filters and all. Used by the
+    # reverse / "referenced_by" extraction so a parent table with no belongs_to
+    # path to the dump target (e.g. active_storage_blobs) is constrained to only
+    # the rows referenced by an extractable child table:
+    #
+    #   <parent>.<pk> IN (SELECT <child>.<fk> FROM <child> WHERE <child filters>)
+    #
+    # `query` is the child's `Select` already projected to the foreign-key
+    # column that points at the parent.
+    SelectSubquery = Struct.new(:query, keyword_init: true) do
+      def to_h
+        { query: query.to_h }
       end
     end
 
@@ -101,6 +119,15 @@ module Exwiw
 
       def join(join_clause)
         @join_clauses << join_clause
+      end
+
+      def to_h
+        {
+          from: from_table_name,
+          columns: select_all ? "*" : columns.map { |c| { name: c.name, value: c.value } },
+          joins: join_clauses.map(&:to_h),
+          where: where_clauses.map { |w| w.is_a?(String) ? w : w.to_h },
+        }
       end
 
       private def map_column_value(columns)

--- a/lib/exwiw/query_ast_builder.rb
+++ b/lib/exwiw/query_ast_builder.rb
@@ -2,17 +2,18 @@
 
 module Exwiw
   class QueryAstBuilder
-    def self.run(table_name, table_by_name, dump_target, logger)
-      new(table_name, table_by_name, dump_target, logger).run
+    def self.run(table_name, table_by_name, dump_target, logger, allow_reverse: true)
+      new(table_name, table_by_name, dump_target, logger, allow_reverse: allow_reverse).run
     end
 
     attr_reader :table_name, :table_by_name, :dump_target
 
-    def initialize(table_name, table_by_name, dump_target, logger)
+    def initialize(table_name, table_by_name, dump_target, logger, allow_reverse: true)
       @table_name = table_name
       @table_by_name = table_by_name
       @dump_target = dump_target
       @logger = logger
+      @allow_reverse = allow_reverse
     end
 
     def run
@@ -20,6 +21,19 @@ module Exwiw
 
       where_clauses = build_where_clauses(table, dump_target)
       join_clauses = build_join_clauses(table, table_by_name, dump_target)
+
+      # Reverse / "referenced_by" extraction. A table with no belongs_to path to
+      # the dump target produces no where/join clauses and would otherwise dump
+      # every row (see the "no relation -> dump all" case). If an extractable
+      # child table references it via a foreign key (e.g. active_storage_blobs is
+      # referenced by active_storage_attachments.blob_id), constrain it to just
+      # the referenced ids instead. Disabled (@allow_reverse=false) while building
+      # a child's subquery, so this never recurses.
+      if @allow_reverse && table.name != dump_target.table_name &&
+         where_clauses.empty? && join_clauses.empty?
+        reverse_clause = build_referenced_by_clause(table)
+        where_clauses.push(reverse_clause) if reverse_clause
+      end
 
       QueryAst::Select.new.tap do |ast|
         ast.from(table.name)
@@ -98,6 +112,61 @@ module Exwiw
       end
 
       join_clauses
+    end
+
+    # Builds a `pk IN (SELECT child.fk FROM <child extraction query>)` clause
+    # for a table that is referenced by an extractable child table but has no
+    # belongs_to of its own toward the dump target. Returns nil when there is no
+    # such (single, unambiguous) referencer, leaving the caller to fall back to
+    # the dump-all behavior.
+    private def build_referenced_by_clause(table)
+      candidates = table_by_name.each_value.filter_map do |other|
+        next if other.name == table.name
+
+        relation = other.belongs_to(table.name)
+        # A polymorphic foreign key stores ids of several models in one column,
+        # so projecting it would pull in unrelated parents. Skip it here; the
+        # non-polymorphic blob_id on active_storage_attachments is what we want.
+        next if relation.nil? || relation.polymorphic?
+
+        # Build the child's own extraction query. allow_reverse:false stops a
+        # chain of FK-less tables from recursing back into each other.
+        child_query = self.class.run(other.name, table_by_name, dump_target, @logger, allow_reverse: false)
+
+        # Only an *already constrained* child narrows anything; an unconstrained
+        # child would select every fk value (i.e. dump all) and not help.
+        next unless child_query.where_clauses.any? || child_query.join_clauses.any?
+
+        [relation, child_query]
+      end
+
+      # Scope: only the unambiguous single-referencer case. Multiple referencers
+      # would need their subqueries OR'd together (not yet supported); falling
+      # back to dump-all preserves today's behavior for those.
+      if candidates.size != 1
+        if candidates.size > 1
+          @logger.debug("  #{table.name} has multiple referencing tables; skipping reverse extraction (dump all).")
+        end
+        return nil
+      end
+
+      relation, child_query = candidates.first
+
+      # Project the child's extraction query down to just the foreign key that
+      # points at `table`. Force a plain column so any masking/raw_sql configured
+      # on that column does not corrupt the id comparison.
+      fk_column = TableColumn.from_symbol_keys(name: relation.foreign_key)
+      projected = QueryAst::Select.new
+      projected.from(child_query.from_table_name)
+      projected.select([fk_column])
+      child_query.join_clauses.each { |j| projected.join(j) }
+      child_query.where_clauses.each { |w| projected.where(w) }
+
+      QueryAst::WhereClause.new(
+        column_name: table.primary_key,
+        operator: :in_subquery,
+        value: QueryAst::SelectSubquery.new(query: projected)
+      )
     end
 
     private def build_where_clauses(table, dump_target)

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -5,6 +5,20 @@ require "json"
 
 module Exwiw
   class SchemaGenerator
+    # ActiveStorage tracks generated image variants in this table. Its rows are
+    # derivative and regenerable — ActiveStorage lazily (re)creates a variant the
+    # next time it is requested — so there is little value in exporting them. More
+    # importantly, the table has no belongs_to path to any dump target, which
+    # would land it in QueryAstBuilder's "no relation -> dump all" branch, while
+    # its `blob_id` references active_storage_blobs, which the reverse
+    # "referenced_by" extraction narrows to only the attachment-referenced blobs.
+    # A full variant_records dump can therefore reference blobs that were never
+    # exported (a foreign-key violation on import). So the table is emitted with
+    # `ignore: true` (data extraction skipped) and excluded as a polymorphic
+    # `record` target so the non-ignored attachments table carries no dangling
+    # belongs_to to it.
+    ACTIVE_STORAGE_VARIANT_RECORDS_TABLE = "active_storage_variant_records"
+
     def self.from_rails_application(output_dir:)
       Rails.application.eager_load!
       new(models: ActiveRecord::Base.descendants, output_dir: output_dir)
@@ -91,6 +105,20 @@ module Exwiw
             ignore: true,
             comment: "exwiw does not support composite primary keys " \
                      "(#{primary_key.join(', ')}); data extraction is skipped.",
+            belongs_tos: aggregate_belongs_tos(model_group),
+            columns: representative.column_names.map { |name| { name: name } },
+          )
+        elsif table_name == ACTIVE_STORAGE_VARIANT_RECORDS_TABLE
+          # See ACTIVE_STORAGE_VARIANT_RECORDS_TABLE. Emitted with ignore:true so
+          # the derivative variant rows are not dumped; primary_key/columns are
+          # kept so a user can remove `ignore` to opt back in if they really want
+          # to export them.
+          TableConfig.from_symbol_keys(
+            name: table_name,
+            primary_key: primary_key,
+            ignore: true,
+            comment: "ActiveStorage variant tracking records are derivative and " \
+                     "regenerable; data extraction is skipped. Remove `ignore` to export them.",
             belongs_tos: aggregate_belongs_tos(model_group),
             columns: representative.column_names.map { |name| { name: name } },
           )
@@ -203,6 +231,12 @@ module Exwiw
     # belongs_to ordering stable.
     private def polymorphic_target_models(association_name)
       concrete_models.select do |model|
+        # active_storage_variant_records is ignored (see the constant), so it must
+        # not be expanded as a polymorphic target — otherwise the non-ignored
+        # attachments table would carry a dangling belongs_to to an ignored table,
+        # which is rejected at load time.
+        next false if model.table_name == ACTIVE_STORAGE_VARIANT_RECORDS_TABLE
+
         (model.reflect_on_all_associations(:has_many) +
          model.reflect_on_all_associations(:has_one))
           .any? { |reflection| reflection.options[:as] == association_name }

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -502,6 +502,54 @@ RSpec.describe Exwiw::QueryAstBuilder do
           expect(built_query_ast.join_clauses).to eq([])
         end
       end
+
+      context 'when an additional unconstrained referencer exists (active_storage_variant_records)' do
+        # Real ActiveStorage also has active_storage_variant_records.blob_id
+        # pointing at blobs. On paper that makes blobs a *multi-referencer*
+        # table, which the reverse-extraction guards against (multiple
+        # referencers would need OR'd subqueries, not yet supported). But
+        # variant_records has no path of its own to the dump target, so its
+        # child query is unconstrained and filtered out as a candidate. blobs
+        # therefore stays a single-referencer case (attachments only) and is
+        # still narrowed correctly rather than dumping every blob.
+        let(:variant_records_table) do
+          Exwiw::TableConfig.from_symbol_keys(
+            name: 'active_storage_variant_records',
+            primary_key: 'id',
+            belongs_tos: [
+              { table_name: 'active_storage_blobs', foreign_key: 'blob_id' },
+            ],
+            columns: [
+              { name: 'id' },
+              { name: 'blob_id' },
+              { name: 'variation_digest' },
+            ],
+          )
+        end
+        let(:all_tables) { [blobs_table, attachments_table, variant_records_table, as_users_table] }
+
+        it 'still narrows blobs to the attachments-referenced ids only' do
+          expect(built_query_ast.from_table_name).to eq('active_storage_blobs')
+          expect(built_query_ast.join_clauses).to eq([])
+          expect(built_query_ast.where_clauses.map(&:to_h)).to eq([
+            {
+              column_name: 'id',
+              operator: :in_subquery,
+              value: {
+                query: {
+                  from: 'active_storage_attachments',
+                  columns: [{ name: 'blob_id', value: 'blob_id' }],
+                  joins: [],
+                  where: [
+                    { column_name: 'record_id', operator: :eq, value: [1] },
+                    { column_name: 'record_type', operator: :eq, value: ['AsUser'] },
+                  ],
+                },
+              },
+            },
+          ])
+        end
+      end
     end
 
     context 'when the table has no relation with dump target table' do

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -394,6 +394,116 @@ RSpec.describe Exwiw::QueryAstBuilder do
       end
     end
 
+    context 'when the table is referenced by an extractable child but has no relation of its own (ActiveStorage blobs)' do
+      # Mirrors ActiveStorage: active_storage_blobs has no belongs_to, but
+      # active_storage_attachments.blob_id references it AND attachments are
+      # extractable via the polymorphic `record` belongs_to to the dump target.
+      # The blobs query should be narrowed to just the referenced blob ids
+      # instead of dumping every blob.
+      let(:dump_target) { Exwiw::DumpTarget.new(table_name: 'as_users', ids: [1]) }
+      let(:blobs_table) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'active_storage_blobs',
+          primary_key: 'id',
+          belongs_tos: [],
+          columns: [{ name: 'id' }, { name: 'key' }, { name: 'filename' }],
+        )
+      end
+      let(:attachments_table) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'active_storage_attachments',
+          primary_key: 'id',
+          belongs_tos: [
+            { table_name: 'active_storage_blobs', foreign_key: 'blob_id' },
+            {
+              table_name: 'as_users',
+              foreign_key: 'record_id',
+              foreign_type: 'record_type',
+              type_value: 'AsUser',
+            },
+          ],
+          columns: [
+            { name: 'id' },
+            { name: 'name' },
+            { name: 'record_type' },
+            { name: 'record_id' },
+            { name: 'blob_id' },
+          ],
+        )
+      end
+      let(:as_users_table) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'as_users',
+          primary_key: 'id',
+          belongs_tos: [],
+          columns: [{ name: 'id' }, { name: 'name' }],
+        )
+      end
+      let(:all_tables) { [blobs_table, attachments_table, as_users_table] }
+      let(:table) { blobs_table }
+
+      it 'constrains blobs to the ids referenced by the extracted attachments' do
+        expect(built_query_ast.from_table_name).to eq('active_storage_blobs')
+        expect(built_query_ast.join_clauses).to eq([])
+        expect(built_query_ast.where_clauses.map(&:to_h)).to eq([
+          {
+            column_name: 'id',
+            operator: :in_subquery,
+            value: {
+              query: {
+                from: 'active_storage_attachments',
+                columns: [{ name: 'blob_id', value: 'blob_id' }],
+                joins: [],
+                where: [
+                  { column_name: 'record_id', operator: :eq, value: [1] },
+                  { column_name: 'record_type', operator: :eq, value: ['AsUser'] },
+                ],
+              },
+            },
+          },
+        ])
+      end
+
+      it 'compiles to a nested IN-subquery SELECT for SQLite' do
+        adapter = Exwiw::Adapter::SqliteAdapter.new(
+          Exwiw::ConnectionConfig.new(
+            adapter: 'sqlite', database_name: 'tmp/test.sqlite3',
+            host: nil, port: nil, user: nil, password: nil
+          ),
+          logger,
+        )
+
+        expect(adapter.compile_ast(built_query_ast)).to eq(
+          'SELECT active_storage_blobs.id, active_storage_blobs.key, active_storage_blobs.filename ' \
+          'FROM active_storage_blobs ' \
+          'WHERE active_storage_blobs.id IN (' \
+          'SELECT active_storage_attachments.blob_id FROM active_storage_attachments ' \
+          "WHERE active_storage_attachments.record_id = 1 AND active_storage_attachments.record_type = 'AsUser')"
+        )
+      end
+
+      context 'when the referencer is itself unconstrained (no path to the dump target)' do
+        # If active_storage_attachments has no relation to the dump target, it
+        # would dump all attachments, so reverse extraction cannot narrow blobs
+        # and we fall back to dumping all blobs.
+        let(:attachments_table) do
+          Exwiw::TableConfig.from_symbol_keys(
+            name: 'active_storage_attachments',
+            primary_key: 'id',
+            belongs_tos: [
+              { table_name: 'active_storage_blobs', foreign_key: 'blob_id' },
+            ],
+            columns: [{ name: 'id' }, { name: 'blob_id' }],
+          )
+        end
+
+        it 'falls back to dumping all blobs' do
+          expect(built_query_ast.where_clauses).to eq([])
+          expect(built_query_ast.join_clauses).to eq([])
+        end
+      end
+    end
+
     context 'when the table has no relation with dump target table' do
       let(:table) { system_announcements_table(:sqlite) }
 

--- a/spec/schema_generator_active_storage_spec.rb
+++ b/spec/schema_generator_active_storage_spec.rb
@@ -38,18 +38,18 @@ require "sqlite3"
 #     active_storage_blobs as a foreign key, which keeps blobs ordered before
 #     attachments at insert time.
 #
-# The *blobs* side, however, is NOT yet fully handled at dump time. exwiw only
-# propagates downward along belongs_to: it extracts a table by finding a
-# belongs_to path FROM that table TO the dump target (QueryAstBuilder#
-# find_path_to_dump_target). active_storage_blobs has no belongs_to at all, so
-# it has no path to the target and falls into the "no relation -> dump all
-# records" branch — every blob in the database is exported, not just the ones
-# referenced by the extracted attachments. Extracting only the referenced blobs
-# needs a separate "reverse"/"referenced_by" mechanism (blobs WHERE id IN
-# (SELECT blob_id FROM <extracted attachments>)) and is left to a follow-up.
+# The *blobs* side needs more than schema generation. exwiw only propagates
+# downward along belongs_to: it extracts a table by finding a belongs_to path
+# FROM that table TO the dump target (QueryAstBuilder#find_path_to_dump_target).
+# active_storage_blobs has no belongs_to at all, so it has no path to the target
+# and would fall into the "no relation -> dump all records" branch. That gap is
+# now closed at dump time by QueryAstBuilder's reverse/"referenced_by" mechanism
+# (blobs WHERE id IN (SELECT blob_id FROM <extracted attachments>)); see
+# query_ast_builder_spec.rb's "referenced by an extractable child" contexts.
 #
 # These specs therefore lock in the schema-generation half (the belongs_tos that
-# following the macros yields). The fixtures replicate exactly what the macros
+# following the macros yields); the reverse-extraction half is covered in
+# query_ast_builder_spec.rb. The fixtures replicate exactly what the macros
 # generate (the gem itself is not a dependency), mirroring the approach in
 # schema_generator_habtm_spec.rb.
 module Exwiw

--- a/spec/schema_generator_active_storage_spec.rb
+++ b/spec/schema_generator_active_storage_spec.rb
@@ -96,6 +96,25 @@ module Exwiw
                class_name: "Exwiw::ActiveStorageFixtures::AsBlob",
                source: :blob
     end
+
+    # ActiveStorage::VariantRecord — tracks generated image variants. It is a
+    # plain ActiveRecord model that `belongs_to :blob` and itself declares
+    # `has_one_attached :image` (=> `has_one :image_attachment, as: :record`),
+    # so the polymorphic `record` belongs_to on AsAttachment would otherwise
+    # expand to include it just like User / Product.
+    class Variant < ::ActiveRecord::Base
+      self.table_name = "active_storage_variant_records"
+      belongs_to :blob, class_name: "Exwiw::ActiveStorageFixtures::AsBlob"
+      has_one :image_attachment,
+              -> { where(name: "image") },
+              class_name: "Exwiw::ActiveStorageFixtures::AsAttachment",
+              as: :record,
+              inverse_of: :record
+      has_one :image_blob,
+              through: :image_attachment,
+              class_name: "Exwiw::ActiveStorageFixtures::AsBlob",
+              source: :blob
+    end
   end
 
   RSpec.describe SchemaGenerator do
@@ -120,6 +139,10 @@ module Exwiw
         end
         conn.create_table(:as_users) { |t| t.string :name }
         conn.create_table(:as_products) { |t| t.string :name }
+        conn.create_table(:active_storage_variant_records) do |t|
+          t.bigint :blob_id, null: false
+          t.string :variation_digest, null: false
+        end
       end
 
       after(:all) do
@@ -185,6 +208,57 @@ module Exwiw
         # as_products configs.
         expect(tables_by_name["as_users"].belongs_tos).to be_empty
         expect(tables_by_name["as_products"].belongs_tos).to be_empty
+      end
+
+      context "when ActiveStorage::VariantRecord is present" do
+        # active_storage_variant_records holds derivative, lazily/async-generated
+        # variant tracking rows. It has no belongs_to path to any dump target, so
+        # exwiw would otherwise dump it in full (the "no relation -> dump all"
+        # branch). That is both wasteful and unsafe: variant_records.blob_id
+        # references active_storage_blobs, which the reverse "referenced_by"
+        # extraction narrows to only the attachment-referenced blobs, so a
+        # full variant_records dump can point at blobs that were never exported
+        # (foreign-key violation on import). The variants are regenerable, so the
+        # table should be marked ignore:true and excluded from extraction.
+        let(:models) do
+          [
+            ActiveStorageFixtures::AsBlob,
+            ActiveStorageFixtures::AsAttachment,
+            ActiveStorageFixtures::User,
+            ActiveStorageFixtures::Product,
+            ActiveStorageFixtures::Variant,
+          ]
+        end
+
+        it "marks active_storage_variant_records as ignore:true" do
+          expect(tables_by_name["active_storage_variant_records"].ignore).to eq(true)
+        end
+
+        it "keeps a non-empty config (columns/primary_key) as a signpost" do
+          variant = tables_by_name["active_storage_variant_records"]
+          expect(variant.primary_key).to eq("id")
+          expect(variant.column_names).to include("blob_id", "variation_digest")
+        end
+
+        it "excludes variant records from the attachments polymorphic `record` expansion" do
+          poly = tables_by_name["active_storage_attachments"].belongs_tos
+            .select(&:polymorphic?)
+            .map(&:table_name)
+
+          # Only the genuine owning models (User / Product) should be expanded;
+          # ActiveStorage::VariantRecord must not become a belongs_to target,
+          # otherwise the non-ignored attachments table would carry a dangling
+          # belongs_to to the ignored variant records table (rejected on load).
+          expect(poly).to contain_exactly("as_users", "as_products")
+        end
+
+        it "leaves no non-ignored table referencing the ignored variant records table" do
+          ignored = tables.select(&:ignore).map(&:name).to_set
+          dangling = tables.reject(&:ignore).flat_map do |t|
+            t.belongs_tos.map(&:table_name).select { |n| ignored.include?(n) }
+          end
+          expect(dangling).to be_empty
+        end
       end
     end
   end

--- a/spec/schema_generator_active_storage_spec.rb
+++ b/spec/schema_generator_active_storage_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "active_record"
+require "sqlite3"
+
+# Strategy check for ActiveStorage support.
+#
+# ActiveStorage stores attachments across two tables:
+#   - active_storage_blobs        (the uploaded file's metadata; no belongs_to)
+#   - active_storage_attachments  (a join row pointing at the blob *and* at the
+#                                  owning record via a polymorphic `record`)
+#
+# The `has_one_attached` / `has_many_attached` macros do NOT add a column to the
+# owning model. Instead they generate ordinary associations:
+#
+#   has_one_attached :avatar  ==>
+#     has_one  :avatar_attachment, class_name: "ActiveStorage::Attachment", as: :record
+#     has_one  :avatar_blob, through: :avatar_attachment, source: :blob
+#
+#   has_many_attached :photos ==>
+#     has_many :photos_attachments, class_name: "ActiveStorage::Attachment", as: :record
+#     has_many :photos_blobs, through: :photos_attachments, source: :blob
+#
+# and `ActiveStorage::Attachment` declares:
+#
+#     belongs_to :record, polymorphic: true
+#     belongs_to :blob,   class_name: "ActiveStorage::Blob"
+#
+# So the existing polymorphic-`belongs_to` machinery already models the
+# *attachments* side correctly *without any ActiveStorage-specific code*:
+#   - the `record` polymorphic belongs_to expands to one entry per model that
+#     declared `has_one_attached` / `has_many_attached` (found via the generated
+#     `has_* ..., as: :record` reflections), letting exwiw extract only the
+#     attachments whose record is one of the dumped rows;
+#   - the `blob` belongs_to correctly records active_storage_attachments ->
+#     active_storage_blobs as a foreign key, which keeps blobs ordered before
+#     attachments at insert time.
+#
+# The *blobs* side, however, is NOT yet fully handled at dump time. exwiw only
+# propagates downward along belongs_to: it extracts a table by finding a
+# belongs_to path FROM that table TO the dump target (QueryAstBuilder#
+# find_path_to_dump_target). active_storage_blobs has no belongs_to at all, so
+# it has no path to the target and falls into the "no relation -> dump all
+# records" branch — every blob in the database is exported, not just the ones
+# referenced by the extracted attachments. Extracting only the referenced blobs
+# needs a separate "reverse"/"referenced_by" mechanism (blobs WHERE id IN
+# (SELECT blob_id FROM <extracted attachments>)) and is left to a follow-up.
+#
+# These specs therefore lock in the schema-generation half (the belongs_tos that
+# following the macros yields). The fixtures replicate exactly what the macros
+# generate (the gem itself is not a dependency), mirroring the approach in
+# schema_generator_habtm_spec.rb.
+module Exwiw
+  module ActiveStorageFixtures
+    # ActiveStorage::Blob — has no belongs_to; attachments point *at* it.
+    class AsBlob < ::ActiveRecord::Base
+      self.table_name = "active_storage_blobs"
+      has_many :attachments,
+               class_name: "Exwiw::ActiveStorageFixtures::AsAttachment",
+               foreign_key: :blob_id
+    end
+
+    # ActiveStorage::Attachment — the polymorphic join row.
+    class AsAttachment < ::ActiveRecord::Base
+      self.table_name = "active_storage_attachments"
+      belongs_to :record, polymorphic: true
+      belongs_to :blob, class_name: "Exwiw::ActiveStorageFixtures::AsBlob"
+    end
+
+    # `has_one_attached :avatar` expands to these two associations.
+    class User < ::ActiveRecord::Base
+      self.table_name = "as_users"
+      has_one :avatar_attachment,
+              -> { where(name: "avatar") },
+              class_name: "Exwiw::ActiveStorageFixtures::AsAttachment",
+              as: :record,
+              inverse_of: :record
+      has_one :avatar_blob,
+              through: :avatar_attachment,
+              class_name: "Exwiw::ActiveStorageFixtures::AsBlob",
+              source: :blob
+    end
+
+    # `has_many_attached :photos` expands to these two associations.
+    class Product < ::ActiveRecord::Base
+      self.table_name = "as_products"
+      has_many :photos_attachments,
+               -> { where(name: "photos") },
+               class_name: "Exwiw::ActiveStorageFixtures::AsAttachment",
+               as: :record,
+               inverse_of: :record
+      has_many :photos_blobs,
+               through: :photos_attachments,
+               class_name: "Exwiw::ActiveStorageFixtures::AsBlob",
+               source: :blob
+    end
+  end
+
+  RSpec.describe SchemaGenerator do
+    describe "ActiveStorage (has_one_attached / has_many_attached) handling" do
+      before(:all) do
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        conn = ActiveRecord::Base.connection
+        conn.create_table(:active_storage_blobs) do |t|
+          t.string :key, null: false
+          t.string :filename, null: false
+          t.string :content_type
+          t.bigint :byte_size, null: false
+          t.string :checksum
+          t.datetime :created_at, null: false
+        end
+        conn.create_table(:active_storage_attachments) do |t|
+          t.string :name, null: false
+          t.string :record_type, null: false
+          t.bigint :record_id, null: false
+          t.bigint :blob_id, null: false
+          t.datetime :created_at, null: false
+        end
+        conn.create_table(:as_users) { |t| t.string :name }
+        conn.create_table(:as_products) { |t| t.string :name }
+      end
+
+      after(:all) do
+        ActiveRecord::Base.remove_connection
+      end
+
+      let(:output_dir) { @output_dir }
+
+      around do |ex|
+        Dir.mktmpdir do |dir|
+          @output_dir = dir
+          ex.run
+        end
+      end
+
+      let(:models) do
+        [
+          ActiveStorageFixtures::AsBlob,
+          ActiveStorageFixtures::AsAttachment,
+          ActiveStorageFixtures::User,
+          ActiveStorageFixtures::Product,
+        ]
+      end
+
+      let(:tables) { described_class.new(models: models, output_dir: output_dir).build_tables }
+      let(:tables_by_name) { tables.each_with_object({}) { |t, h| h[t.name] = t } }
+
+      it "covers both ActiveStorage tables plus the owning models" do
+        expect(tables_by_name.keys).to include(
+          "active_storage_blobs", "active_storage_attachments", "as_users", "as_products",
+        )
+      end
+
+      it "emits no belongs_to on active_storage_blobs (it is the parent table)" do
+        expect(tables_by_name["active_storage_blobs"].belongs_tos).to be_empty
+      end
+
+      it "keeps the non-polymorphic blob foreign key on active_storage_attachments" do
+        non_poly = tables_by_name["active_storage_attachments"].belongs_tos
+          .reject(&:polymorphic?)
+          .map { |b| [b.table_name, b.foreign_key] }
+
+        expect(non_poly).to contain_exactly(["active_storage_blobs", "blob_id"])
+      end
+
+      it "expands the polymorphic `record` into one belongs_to per attached model" do
+        poly = tables_by_name["active_storage_attachments"].belongs_tos
+          .select(&:polymorphic?)
+          .map { |b| [b.table_name, b.foreign_key, b.foreign_type, b.type_value] }
+
+        # Both User (has_one_attached) and Product (has_many_attached) declared a
+        # `has_* ..., as: :record` association, so the polymorphic `record`
+        # belongs_to expands to one entry each, carrying the record_type filter.
+        expect(poly).to contain_exactly(
+          ["as_users", "record_id", "record_type", ActiveStorageFixtures::User.polymorphic_name],
+          ["as_products", "record_id", "record_type", ActiveStorageFixtures::Product.polymorphic_name],
+        )
+      end
+
+      it "does not leak the macro-generated `through` blob associations as belongs_tos" do
+        # `avatar_blob` / `photos_blobs` are `has_* through:` reflections on the
+        # owning models, not belongs_tos, so they must not appear on as_users /
+        # as_products configs.
+        expect(tables_by_name["as_users"].belongs_tos).to be_empty
+        expect(tables_by_name["as_products"].belongs_tos).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

exwiw の ActiveStorage 対応を完成させる。`has_one_attached` / `has_many_attached` で利用される `active_storage_attachments` / `active_storage_blobs` を正しくエクスポートできるようにした。

## 変更内容

- **active_storage_attachments の対応確認とリグレッションスペック追加** (`4b2edfe`)
  - `has_one_attached` / `has_many_attached` マクロを辿ることで、polymorphic belongs_to 経由で `active_storage_attachments` が正しくエクスポートされることを確認
  - リグレッションスペックを追加し、blobs が全件ダンプされる残課題を特定
- **reverse "referenced_by" 抽出の実装** (`7cd22b6`)
  - 抽出された attachments から参照される blob のみに `active_storage_blobs` を絞り込むよう、逆方向の "referenced_by" 抽出（SelectSubquery）を実装
  - 全 blob をダンプする挙動を解消
- **active_storage_variant_records の検証とドキュメント整備** (`aad8887`)
  - `active_storage_variant_records` が blob の逆抽出を壊さないことを検証（標準 ActiveStorage が正しくエクスポートされることを確認）
  - README とスペックに ActiveStorage 対応完了を記載

## 関連

- メモ: ActiveStorage は attachments を polymorphic マクロ経由で抽出し、blobs は reverse "referenced_by" 抽出で絞り込む

fixes https://github.com/heyinc/exwiw/issues/59 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
