### PR TITLE
feat(schema_generator): exwiw:schema:tidy rake タスクを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- New `exwiw:schema:tidy` rake task. It reconciles the existing schema config against the current application schema and removes only what no longer exists: a config file whose table has been dropped is deleted, and columns recorded in a surviving table's config that the table no longer has are dropped from that file. Unlike `schema:generate` it never adds or regenerates entries, so hand-edited `comment` / `ignore` / `replace_with` on surviving tables/columns are preserved. It honors `OUTPUT_DIR_PATH` and the per-database subdirectory layout, and prints the tables/columns it removed.
+
 ## [0.3.8] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- New `exwiw:schema:tidy` rake task. It reconciles the existing schema config against the current application schema and removes only what no longer exists: a config file whose table has been dropped is deleted, and columns recorded in a surviving table's config that the table no longer has are dropped from that file. Unlike `schema:generate` it never adds or regenerates entries, so hand-edited `comment` / `ignore` / `replace_with` on surviving tables/columns are preserved. It honors `OUTPUT_DIR_PATH` and the per-database subdirectory layout, and prints the tables/columns it removed.
+- New `exwiw:schema:tidy` rake task. It reconciles the existing schema config against the live database (read through the database connection, not the models) and removes only what no longer exists there: a config file whose table has been dropped is deleted, and columns recorded in a surviving table's config that the table no longer has are dropped from that file. Because it reads the database directly, a table that still exists in the database but has lost (or never had) a model is kept — only a genuinely-dropped table is removed. Unlike `schema:generate` it never adds or regenerates entries, so hand-edited `comment` / `ignore` / `replace_with` on surviving tables/columns are preserved. It honors `OUTPUT_DIR_PATH` and the per-database subdirectory layout, and prints the tables/columns it removed.
 
 ## [0.3.8] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ OUTPUT_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
 bundle exec rake exwiw:schema:tidy
 ```
 
-`schema:tidy` compares the config files already on disk with the current application schema and removes only what no longer exists:
+`schema:tidy` compares the config files already on disk with the **live database** (read through the database connection, not the models) and removes only what no longer exists there:
 
-- a config file whose table has been removed from the application is **deleted**, and
+- a config file whose table has been dropped from the database is **deleted**, and
 - columns recorded in a surviving table's config that the table no longer has are **dropped** from that file.
+
+Because it reads the database directly, a table that still exists in the database but has lost (or never had) an ActiveRecord model is **kept** — only a table that is genuinely gone is removed. (This is the deliberate counterpart to `generate`, which is model-driven and only ever adds what the models know about.)
 
 It respects `OUTPUT_DIR_PATH` and the per-database subdirectory layout in the same way as `schema:generate`. Unlike `generate`, `tidy` never adds or regenerates entries — every surviving table/column (including hand-edited `comment` / `ignore` / `replace_with`) is left untouched, so it is safe to run on a customized config. The task prints which tables and columns it removed (or that the config was already tidy). Stale `belongs_tos` are not pruned by `tidy`; rerun `schema:generate` to refresh those.
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ By default, the schema files will be saved in the `exwiw` directory. You can spe
 OUTPUT_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
 ```
 
+#### Tidying stale config (`schema:tidy`)
+
+`schema:generate` adds and updates config files for the tables it finds, but it never deletes the config file of a table that has been dropped from the application. To reconcile the existing config against the current schema, run:
+
+```bash
+bundle exec rake exwiw:schema:tidy
+```
+
+`schema:tidy` compares the config files already on disk with the current application schema and removes only what no longer exists:
+
+- a config file whose table has been removed from the application is **deleted**, and
+- columns recorded in a surviving table's config that the table no longer has are **dropped** from that file.
+
+It respects `OUTPUT_DIR_PATH` and the per-database subdirectory layout in the same way as `schema:generate`. Unlike `generate`, `tidy` never adds or regenerates entries — every surviving table/column (including hand-edited `comment` / `ignore` / `replace_with`) is left untouched, so it is safe to run on a customized config. The task prints which tables and columns it removed (or that the config was already tidy). Stale `belongs_tos` are not pruned by `tidy`; rerun `schema:generate` to refresh those.
+
 #### Multiple databases
 
 If the application uses Rails' multiple-database support (`connects_to`), `schema:generate` buckets models by the database they connect to and writes each database's config files into its own subdirectory of the output directory, named after the database config name (`primary`, `analytics`, ...):

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -5,6 +5,30 @@ require "json"
 
 module Exwiw
   class SchemaGenerator
+    # Summary of what `SchemaGenerator#tidy!` removed, returned so callers can
+    # report it. `removed_columns` maps a surviving table's name to the column
+    # names that were dropped from its config.
+    class TidyResult
+      attr_reader :removed_tables, :removed_columns
+
+      def initialize
+        @removed_tables = []
+        @removed_columns = {}
+      end
+
+      def add_removed_table(table_name)
+        @removed_tables << table_name
+      end
+
+      def add_removed_column(table_name, column_name)
+        (@removed_columns[table_name] ||= []) << column_name
+      end
+
+      def empty?
+        @removed_tables.empty? && @removed_columns.empty?
+      end
+    end
+
     # ActiveStorage tracks generated image variants in this table. Its rows are
     # derivative and regenerable — ActiveStorage lazily (re)creates a variant the
     # next time it is requested — so there is little value in exporting them. More
@@ -33,6 +57,52 @@ module Exwiw
       groups = build_table_groups
       write_groups(groups)
       groups
+    end
+
+    # Reconcile the config files already on disk against the current
+    # application schema, removing only what no longer exists:
+    #
+    # - a config file whose table is no longer present is deleted, and
+    # - columns recorded in a surviving table's config that the table no
+    #   longer has are dropped from that file.
+    #
+    # Unlike `generate!`, tidy never adds or regenerates entries: every
+    # surviving table/column — including its hand-edited `comment` / `ignore` /
+    # `replace_with` — is left untouched, and only the stale entries are
+    # stripped. (Removing a deleted column is something `generate!` already does
+    # incidentally via #merge, but `generate!` can never delete the config file
+    # of a removed table, which is the gap this fills.) Returns a TidyResult
+    # describing the removals so callers (e.g. the rake task) can report them.
+    def tidy!
+      result = TidyResult.new
+
+      build_table_groups.each do |db_name, current_tables|
+        dir = config_dir_for(db_name)
+        next unless Dir.exist?(dir)
+
+        current_by_name = current_tables.each_with_object({}) { |t, h| h[t.name] = t }
+
+        Dir[File.join(dir, "*.json")].sort.each do |path|
+          existing = TableConfig.from(JSON.parse(File.read(path)))
+          current_table = current_by_name[existing.name]
+
+          if current_table.nil?
+            File.delete(path)
+            result.add_removed_table(existing.name)
+            next
+          end
+
+          valid_column_names = current_table.column_names.to_set
+          stale_columns = existing.columns.reject { |column| valid_column_names.include?(column.name) }
+          next if stale_columns.empty?
+
+          existing.columns = existing.columns.select { |column| valid_column_names.include?(column.name) }
+          File.write(path, JSON.pretty_generate(existing.to_hash) + "\n")
+          stale_columns.each { |column| result.add_removed_column(existing.name, column.name) }
+        end
+      end
+
+      result
     end
 
     # Returns a Hash keyed by the database name.
@@ -67,9 +137,16 @@ module Exwiw
 
     def write_groups(groups)
       groups.each do |db_name, tables|
-        dir = db_name.nil? ? @output_dir : File.join(@output_dir, db_name)
-        write_files(dir, tables)
+        write_files(config_dir_for(db_name), tables)
       end
+    end
+
+    # The directory a database group's config files live in. A single-database
+    # setup (`db_name` is nil) writes flat into `output_dir`; a multi-database
+    # setup writes into `output_dir/<db_name>/`. Shared by `write_groups` and
+    # `tidy!` so the two operations agree on file locations.
+    private def config_dir_for(db_name)
+      db_name.nil? ? @output_dir : File.join(@output_dir, db_name)
     end
 
     def write_files(dir, tables)

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -59,12 +59,21 @@ module Exwiw
       groups
     end
 
-    # Reconcile the config files already on disk against the current
-    # application schema, removing only what no longer exists:
+    # Reconcile the config files already on disk against the live database,
+    # removing only what no longer exists there:
     #
     # - a config file whose table is no longer present is deleted, and
     # - columns recorded in a surviving table's config that the table no
     #   longer has are dropped from that file.
+    #
+    # The source of truth is the database connection (`data_sources` for table
+    # existence — which covers views too — and `columns` for the column list),
+    # NOT `build_table_groups`. `build_table_groups` only knows about tables
+    # that still have an ActiveRecord model, so reconciling against it would
+    # delete the config of a table that is still present in the database but
+    # has merely lost (or never had) a model. Reading the connection directly
+    # avoids that: only a table that is genuinely gone from the database is
+    # removed.
     #
     # Unlike `generate!`, tidy never adds or regenerates entries: every
     # surviving table/column — including its hand-edited `comment` / `ignore` /
@@ -76,23 +85,22 @@ module Exwiw
     def tidy!
       result = TidyResult.new
 
-      build_table_groups.each do |db_name, current_tables|
+      model_db_groups.each do |db_name, _group_models, conn|
         dir = config_dir_for(db_name)
         next unless Dir.exist?(dir)
 
-        current_by_name = current_tables.each_with_object({}) { |t, h| h[t.name] = t }
+        existing_data_sources = conn.data_sources.to_set
 
         Dir[File.join(dir, "*.json")].sort.each do |path|
           existing = TableConfig.from(JSON.parse(File.read(path)))
-          current_table = current_by_name[existing.name]
 
-          if current_table.nil?
+          unless existing_data_sources.include?(existing.name)
             File.delete(path)
             result.add_removed_table(existing.name)
             next
           end
 
-          valid_column_names = current_table.column_names.to_set
+          valid_column_names = conn.columns(existing.name).map(&:name).to_set
           stale_columns = existing.columns.reject { |column| valid_column_names.include?(column.name) }
           next if stale_columns.empty?
 
@@ -114,18 +122,35 @@ module Exwiw
     #   mapping to that database's table configs. They are written into
     #   `output_dir/<db_name>/`.
     def build_table_groups
+      model_db_groups.each_with_object({}) do |(db_name, group_models, conn), result|
+        result[db_name] = build_tables_for(group_models, conn)
+      end
+    end
+
+    # The per-database grouping that both `build_table_groups` and `tidy!` work
+    # from: `[[db_name, models, connection], ...]`.
+    #
+    # - Single-database setup: one entry keyed by `nil` (configs written flat
+    #   into `output_dir`). When there are no models at all, fall back to the
+    #   default connection so callers still have a connection to inspect.
+    # - Multi-database setup (Rails `connects_to`): one entry per database,
+    #   keyed by `connection_db_config.name` ("primary" / "analytics", ...).
+    #
+    # The db_name <-> connection mapping is necessarily model-derived: which
+    # databases the app talks to is only declared on the model side (via
+    # `connects_to`). What each consumer reads *through* that connection differs
+    # — `build_table_groups` builds configs from the models, while `tidy!`
+    # reads the live database's actual tables/columns.
+    private def model_db_groups
       models = concrete_models
       grouped = models.group_by { |model| database_name_for(model) }
 
       if grouped.size <= 1
         conn = models.empty? ? ActiveRecord::Base.connection : models.first.connection
-        return { nil => build_tables_for(models, conn) }
+        return [[nil, models, conn]]
       end
 
-      grouped.each_with_object({}) do |(db_name, group_models), result|
-        conn = group_models.first.connection
-        result[db_name] = build_tables_for(group_models, conn)
-      end
+      grouped.map { |db_name, group_models| [db_name, group_models, group_models.first.connection] }
     end
 
     # Backwards-compatible flat list of all table configs. Only meaningful for

--- a/lib/tasks/exwiw.rake
+++ b/lib/tasks/exwiw.rake
@@ -11,6 +11,26 @@ namespace :exwiw do
       ).generate!
     end
 
+    desc "Remove tables/columns from the schema config that no longer exist in the application"
+    task tidy: :environment do
+      require "exwiw"
+
+      result = Exwiw::SchemaGenerator.from_rails_application(
+        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw",
+      ).tidy!
+
+      if result.empty?
+        puts "exwiw: schema config is already tidy; nothing to remove."
+      else
+        result.removed_tables.each do |name|
+          puts "exwiw: removed config for table '#{name}' (no longer exists in the application)."
+        end
+        result.removed_columns.each do |table_name, columns|
+          puts "exwiw: removed column(s) #{columns.join(', ')} from '#{table_name}' (no longer in the table)."
+        end
+      end
+    end
+
     desc "Generate schema from a Mongoid application"
     task generate_mongoid: :environment do
       require "exwiw"

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -444,6 +444,54 @@ module Exwiw
         after = Dir[File.join(output_dir, "*.json")].sort.map { |p| [File.basename(p), File.read(p)] }
         expect(after).to eq(before)
       end
+
+      # tidy reconciles against the live database, not against the models. A
+      # table that still exists in the database but has lost (or never had) a
+      # model must keep its config; only its genuinely-absent columns are
+      # pruned. Reconciling against `build_table_groups` (model-driven) would
+      # wrongly delete this config file.
+      context "for a table that exists in the database but has no model" do
+        before(:all) do
+          ActiveRecord::Base.connection.execute(<<~SQL)
+            CREATE TABLE IF NOT EXISTS orphan_records (
+              id INTEGER PRIMARY KEY,
+              kept TEXT
+            )
+          SQL
+        end
+
+        after(:all) do
+          ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS orphan_records")
+        end
+
+        it "keeps the config and prunes only the columns missing from the database" do
+          write_config("orphan_records", {
+            "name" => "orphan_records",
+            "primary_key" => "id",
+            "belongs_tos" => [],
+            "columns" => [
+              { "name" => "id" },
+              { "name" => "kept", "replace_with" => "masked" },
+              { "name" => "ghost_column" },
+            ],
+          })
+
+          # No model maps to orphan_records, so a model-driven reconcile would
+          # delete the file. Pass only Shop to make that unambiguous.
+          result = described_class.new(models: [Shop], output_dir: output_dir).tidy!
+
+          path = File.join(output_dir, "orphan_records.json")
+          expect(File).to exist(path)
+          expect(result.removed_tables).to be_empty
+
+          written = JSON.parse(File.read(path))
+          column_names = written["columns"].map { |c| c["name"] }
+          expect(column_names).to include("id", "kept")
+          expect(column_names).not_to include("ghost_column")
+          expect(written["columns"].find { |c| c["name"] == "kept" }["replace_with"]).to eq("masked")
+          expect(result.removed_columns).to eq("orphan_records" => ["ghost_column"])
+        end
+      end
     end
   end
 end

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -304,6 +304,26 @@ module Exwiw
             .to contain_exactly("analytics_events.json", "schema_migrations.json")
         end
       end
+
+      describe "#tidy!" do
+        it "tidies each database's own subdirectory" do
+          described_class.new(models: multidb_models, output_dir: output_dir).generate!
+          stale_path = File.join(output_dir, "primary", "legacy_things.json")
+          File.write(stale_path, JSON.pretty_generate(
+            "name" => "legacy_things",
+            "primary_key" => "id",
+            "belongs_tos" => [],
+            "columns" => [{ "name" => "id" }],
+          ) + "\n")
+
+          result = described_class.new(models: multidb_models, output_dir: output_dir).tidy!
+
+          expect(File).not_to exist(stale_path)
+          expect(File).to exist(File.join(output_dir, "primary", "shops.json"))
+          expect(File).to exist(File.join(output_dir, "analytics", "analytics_events.json"))
+          expect(result.removed_tables).to contain_exactly("legacy_things")
+        end
+      end
     end
 
     describe "#generate!" do
@@ -348,6 +368,81 @@ module Exwiw
           expected = JSON.parse(File.read(fixture_path))
           expect(actual).to eq(expected), "snapshot mismatch in #{File.basename(fixture_path)}"
         end
+      end
+    end
+
+    describe "#tidy!" do
+      def write_config(name, hash)
+        File.write(File.join(output_dir, "#{name}.json"), JSON.pretty_generate(hash) + "\n")
+      end
+
+      it "deletes the config file of a table that no longer exists" do
+        described_class.new(models: models, output_dir: output_dir).generate!
+        write_config("legacy_things", {
+          "name" => "legacy_things",
+          "primary_key" => "id",
+          "belongs_tos" => [],
+          "columns" => [{ "name" => "id" }, { "name" => "value" }],
+        })
+
+        result = described_class.new(models: models, output_dir: output_dir).tidy!
+
+        expect(File).not_to exist(File.join(output_dir, "legacy_things.json"))
+        expect(File).to exist(File.join(output_dir, "shops.json"))
+        expect(result.removed_tables).to contain_exactly("legacy_things")
+        expect(result.removed_columns).to be_empty
+      end
+
+      it "drops columns that the table no longer has from a surviving config" do
+        write_config("shops", {
+          "name" => "shops",
+          "primary_key" => "id",
+          "belongs_tos" => [],
+          "columns" => [
+            { "name" => "id" },
+            { "name" => "name", "replace_with" => "masked" },
+            { "name" => "ghost_column" },
+          ],
+        })
+
+        result = described_class.new(models: [Shop], output_dir: output_dir).tidy!
+
+        written = JSON.parse(File.read(File.join(output_dir, "shops.json")))
+        expect(written["columns"].map { |c| c["name"] }).not_to include("ghost_column")
+        expect(written["columns"].map { |c| c["name"] }).to include("id", "name")
+        expect(result.removed_columns).to eq("shops" => ["ghost_column"])
+        expect(result.removed_tables).to be_empty
+      end
+
+      it "preserves hand-edited attributes on surviving columns" do
+        write_config("shops", {
+          "name" => "shops",
+          "primary_key" => "id",
+          "belongs_tos" => [],
+          "columns" => [
+            { "name" => "id" },
+            { "name" => "name", "replace_with" => "masked", "comment" => "PII" },
+            { "name" => "ghost_column" },
+          ],
+        })
+
+        described_class.new(models: [Shop], output_dir: output_dir).tidy!
+
+        written = JSON.parse(File.read(File.join(output_dir, "shops.json")))
+        name_column = written["columns"].find { |c| c["name"] == "name" }
+        expect(name_column["replace_with"]).to eq("masked")
+        expect(name_column["comment"]).to eq("PII")
+      end
+
+      it "reports nothing and leaves files intact when the config already matches the schema" do
+        described_class.new(models: models, output_dir: output_dir).generate!
+        before = Dir[File.join(output_dir, "*.json")].sort.map { |p| [File.basename(p), File.read(p)] }
+
+        result = described_class.new(models: models, output_dir: output_dir).tidy!
+
+        expect(result).to be_empty
+        after = Dir[File.join(output_dir, "*.json")].sort.map { |p| [File.basename(p), File.read(p)] }
+        expect(after).to eq(before)
       end
     end
   end

--- a/spec/schema_generator_spec.rb
+++ b/spec/schema_generator_spec.rb
@@ -46,6 +46,21 @@ module Exwiw
     end
   end
 
+  # Plain models backed by throwaway tables, used by the end-to-end tidy test
+  # that applies a real DDL change to the live database and checks that tidy
+  # reconciles the on-disk config to match. They are ::ActiveRecord::Base
+  # descendants (not ApplicationRecord) so they stay out of the `models` list
+  # the other examples build from `ApplicationRecord.descendants`.
+  module SchemaGeneratorE2eFixtures
+    class KeptTable < ::ActiveRecord::Base
+      self.table_name = "e2e_kept"
+    end
+
+    class DoomedTable < ::ActiveRecord::Base
+      self.table_name = "e2e_doomed"
+    end
+  end
+
   # Real Rails multi-DB setup: two abstract bases wired through
   # `connects_to` against named entries in `ActiveRecord::Base.configurations`,
   # exactly as a `database.yml`-backed app would. This makes
@@ -491,6 +506,59 @@ module Exwiw
           expect(written["columns"].find { |c| c["name"] == "kept" }["replace_with"]).to eq("masked")
           expect(result.removed_columns).to eq("orphan_records" => ["ghost_column"])
         end
+      end
+    end
+
+    # End-to-end: start from config that `generate!` produced against the live
+    # schema, apply a real DDL change to the database (drop a table, drop a
+    # column), then check that `tidy!` reconciles the on-disk config to match.
+    # Unlike the focused `#tidy!` examples above (which hand-write config with
+    # made-up names), this drives the generate -> schema-change -> tidy flow
+    # against actual tables.
+    describe "reconciling config after a real schema change" do
+      before(:all) do
+        conn = ActiveRecord::Base.connection
+        conn.execute("DROP TABLE IF EXISTS e2e_kept")
+        conn.execute("DROP TABLE IF EXISTS e2e_doomed")
+        conn.execute("CREATE TABLE e2e_kept (id INTEGER PRIMARY KEY, name TEXT, doomed_col TEXT)")
+        conn.execute("CREATE TABLE e2e_doomed (id INTEGER PRIMARY KEY)")
+      end
+
+      after(:all) do
+        conn = ActiveRecord::Base.connection
+        conn.execute("DROP TABLE IF EXISTS e2e_kept")
+        conn.execute("DROP TABLE IF EXISTS e2e_doomed")
+      end
+
+      it "deletes config for a dropped table and prunes a dropped column" do
+        e2e_models = [
+          SchemaGeneratorE2eFixtures::KeptTable,
+          SchemaGeneratorE2eFixtures::DoomedTable,
+        ]
+        kept_path = File.join(output_dir, "e2e_kept.json")
+        doomed_path = File.join(output_dir, "e2e_doomed.json")
+        column_names = ->(path) { JSON.parse(File.read(path))["columns"].map { |c| c["name"] } }
+
+        # 1. Generate config from the real schema.
+        described_class.new(models: e2e_models, output_dir: output_dir).generate!
+        expect(File).to exist(doomed_path)
+        expect(column_names.call(kept_path)).to include("id", "name", "doomed_col")
+
+        # 2. Apply a real schema change to the live database.
+        conn = ActiveRecord::Base.connection
+        conn.execute("DROP TABLE e2e_doomed")
+        conn.execute("ALTER TABLE e2e_kept DROP COLUMN doomed_col")
+        conn.schema_cache.clear!
+        e2e_models.each(&:reset_column_information)
+
+        # 3. Tidy reconciles the on-disk config to the new schema.
+        result = described_class.new(models: e2e_models, output_dir: output_dir).tidy!
+
+        expect(File).not_to exist(doomed_path)
+        expect(File).to exist(kept_path)
+        expect(column_names.call(kept_path)).to contain_exactly("id", "name")
+        expect(result.removed_tables).to contain_exactly("e2e_doomed")
+        expect(result.removed_columns).to eq("e2e_kept" => ["doomed_col"])
       end
     end
   end


### PR DESCRIPTION
## 概要

オンディスクのスキーマ設定を整理する `exwiw:schema:tidy` rake タスクを追加し、その判定基準を実DBスキーマに揃えました。

## 変更内容

- `exwiw:schema:tidy` rake タスクを新規追加
  - 削除されたテーブルに対応する設定ファイルを削除
  - 存在しなくなったカラムを設定から除去
  - ユーザーによるカスタマイズ（`comment` / `ignore` / `replace_with`）は保持
- **判定基準を実DB（接続経由）に変更**
  - モデル駆動の `build_table_groups` ではなく `conn.data_sources` / `conn.columns` を参照
  - DBに実在するがモデルを失った（or 元々モデルレスの）テーブルの設定を誤削除しないように修正
  - `build_table_groups` と共有する `model_db_groups` ヘルパーを抽出（挙動不変）
  - `generate!` は belongs_tos/primary_key 等が必要なため従来どおりモデル駆動（非対称は意図的）
- `README.md` / `CHANGELOG.md` を更新

## テスト

- `spec/schema_generator_spec.rb` にケースを追加（モデルレスの実在テーブルが保持されることの回帰テスト含む）
- `bundle exec rspec spec/schema_generator_spec.rb` → 27 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)