### PR TITLE
feat: MongoidSchemaGenerator に skip_unsupported モードを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `MongoidSchemaGenerator` gains an opt-in `skip_unsupported:` mode (via the rake task, `EXWIW_SKIP_UNSUPPORTED=1 bundle exec rake exwiw:schema:generate_mongoid`). When enabled, generation no longer aborts on a construct exwiw cannot represent: an unresolvable `belongs_to` (whose target class no longer exists — e.g. a stale relation left behind after the model was removed) is skipped with a stderr warning while its foreign-key column is still kept as a field, and a polymorphic / self-referential-cyclic / unresolvable-parent `embedded_in` collection is emitted as a top-level `ignore: true` config annotated with a `comment` explaining why — so it is not wrongly dumped as its own collection — instead of raising. Off by default, so the existing fail-loud behavior is unchanged for callers that do not opt in. `MongodbCollectionConfig` now also carries an optional collection-level `comment` attribute, preserved across regeneration like the field / belongs_to `comment`.
+
 ## [0.4.0] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,6 +200,15 @@ Models in an inheritance hierarchy whose subclasses share the base's collection 
 
 Regeneration preserves hand-edited `replace_with`, `filter`, `ignore`, and `bulk_insert_chunk_size` values, like the ActiveRecord generator. Indexes are not written to the config — they are introspected from the live database at dump time (see [MongoDB notes](#mongodb-notes)). Polymorphic `belongs_to` is not yet expanded by this task.
 
+By default the task **aborts** when a model uses a construct exwiw cannot represent: a `belongs_to` whose target class can no longer be resolved (a stale relation left behind after its model was removed), or a polymorphic / self-referential-cyclic / unresolvable-parent `embedded_in` (see the cases above). Set `EXWIW_SKIP_UNSUPPORTED=1` to keep going instead:
+
+```bash
+EXWIW_SKIP_UNSUPPORTED=1 bundle exec rake exwiw:schema:generate_mongoid
+```
+
+- An unresolvable `belongs_to` is dropped from the collection's `belongs_tos` (its foreign-key column is still kept as an ordinary field, like the polymorphic / HABTM cases) and a warning naming the relation is printed to stderr.
+- An unrepresentable `embedded_in` collection is emitted as a **top-level** config marked `"ignore": true` with a `comment` recording why, and a warning is printed. `ignore: true` keeps it out of extraction so it is not wrongly dumped as its own collection; to actually dump/mask such an embedded collection, define its `embedded_in` config by hand (see [Embedded documents](#embedded-documents)). This is useful for bootstrapping a config against a large app where a handful of legacy/polymorphic collections would otherwise block the whole run.
+
 ### Configuration
 
 This is an example of the one table schema:

--- a/lib/exwiw/mongodb_collection_config.rb
+++ b/lib/exwiw/mongodb_collection_config.rb
@@ -14,6 +14,12 @@ module Exwiw
     attribute :fields, array(MongodbField)
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
     attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
+    # Free-form note. Purely informational — exwiw never reads it — and preserved
+    # across `MongoidSchemaGenerator` regeneration like the field / belongs_to
+    # `comment`. The generator also emits one when, under `skip_unsupported`, it
+    # marks an unrepresentable collection `ignore: true`, to record why extraction
+    # was skipped.
+    attribute :comment, optional(String), skip_serializing_if_nil: true
 
     # Marks this config as physically embedded inside another collection's
     # documents. When set, this config is not processed as a standalone dump
@@ -62,6 +68,10 @@ module Exwiw
         merged.filter = filter
         merged.bulk_insert_chunk_size = bulk_insert_chunk_size
         merged.ignore = ignore
+        # A freshly generated comment (e.g. the skip_unsupported marker) wins so
+        # it stays accurate; otherwise a hand-added note on a normal collection
+        # is kept.
+        merged.comment = passed.comment || comment
         merged.embedded_in = passed.embedded_in
 
         # Structural facts of each belongs_to come from the freshly generated

--- a/lib/exwiw/mongoid_schema_generator.rb
+++ b/lib/exwiw/mongoid_schema_generator.rb
@@ -14,14 +14,38 @@ module Exwiw
   # (`fields`, `relations`, `collection_name`), so it does not require a live
   # MongoDB connection.
   class MongoidSchemaGenerator
-    def self.from_rails_application(output_dir:)
-      Rails.application.eager_load!
-      new(models: ::Mongoid.models, output_dir: output_dir)
+    # Raised when an embedded collection's `embedded_in` cannot be expressed as
+    # an exwiw config (polymorphic embedding, self-referential/cyclic embedding,
+    # or an unresolvable embedding-parent class). A subclass of ArgumentError so
+    # the historical `raise_error(ArgumentError, ...)` contract is preserved.
+    # Under `skip_unsupported` the generator rescues this and emits an
+    # `ignore: true` config instead of aborting the whole run.
+    class UnsupportedEmbedding < ArgumentError
+      # A concise phrase (as opposed to the long, actionable exception message)
+      # recorded as the generated config's `comment`.
+      attr_reader :reason
+
+      def initialize(message, reason:)
+        super(message)
+        @reason = reason
+      end
     end
 
-    def initialize(models:, output_dir:)
+    # `skip_unsupported`: when true, the generator does not abort on a construct
+    # it cannot represent. It skips an unresolvable `belongs_to` (keeping the
+    # foreign-key field) and emits an unrepresentable embedded collection as an
+    # `ignore: true` top-level config annotated with a `comment`, warning to
+    # stderr in both cases. Off by default, so the historical fail-loud behavior
+    # is unchanged unless a caller opts in.
+    def self.from_rails_application(output_dir:, skip_unsupported: false)
+      Rails.application.eager_load!
+      new(models: ::Mongoid.models, output_dir: output_dir, skip_unsupported: skip_unsupported)
+    end
+
+    def initialize(models:, output_dir:, skip_unsupported: false)
       @models = models
       @output_dir = output_dir
+      @skip_unsupported = skip_unsupported
     end
 
     def generate!
@@ -78,7 +102,31 @@ module Exwiw
         # supported (MongodbCollectionConfig rejects them), so embedded configs
         # always carry an empty belongs_tos and instead declare where they live.
         attrs[:belongs_tos] = []
-        attrs[:embedded_in] = embedded_in_for(ordered.find(&:embedded?))
+        begin
+          attrs[:embedded_in] = embedded_in_for(ordered.find(&:embedded?))
+        rescue => e
+          # Known-unrepresentable shapes arrive as UnsupportedEmbedding (with a
+          # concise reason). Without skip_unsupported, re-raise so the historical
+          # fail-loud behavior is preserved. The broad rescue is a deliberate
+          # safety net for skip_unsupported (a best-effort bootstrapping mode):
+          # any other error while deriving the embedding is turned into an
+          # `ignore: true` config too, so a single odd model never aborts the run.
+          raise e unless @skip_unsupported
+
+          reason =
+            if e.is_a?(UnsupportedEmbedding)
+              e.reason
+            else
+              "raised #{e.class} while deriving embedded_in (#{e.message.lines.first&.strip})"
+            end
+
+          # Emit the collection as a top-level config marked `ignore: true` so it
+          # is NOT (wrongly) dumped as its own collection, and record why. The
+          # user can hand-write its embedded_in config later to dump/mask it.
+          warn("exwiw: skip_unsupported: '#{collection_name}' #{reason}; emitting ignore:true (define embedded_in by hand to dump/mask it).")
+          attrs[:ignore] = true
+          attrs[:comment] = "exwiw could not derive embedded_in (#{reason}); marked ignore:true. Define this collection's embedded_in config by hand to dump/mask it."
+        end
       else
         attrs[:belongs_tos] = aggregate_belongs_tos(ordered)
       end
@@ -168,8 +216,23 @@ module Exwiw
       # same belongs_to twice, so uniq them.
       belongs_to_assocs
         .reject(&:polymorphic?)
-        .map { |assoc| { table_name: assoc.klass.collection_name.to_s, foreign_key: assoc.foreign_key } }
+        .filter_map { |assoc| belongs_to_for(assoc) }
         .uniq
+    end
+
+    # Resolves a referenced belongs_to to a `{ table_name, foreign_key }` pair.
+    # `assoc.klass` raises NameError when the association's target class no longer
+    # exists (a stale/legacy `belongs_to`, e.g. pointing at a model removed years
+    # ago). Under `skip_unsupported` such a relation is skipped with a warning —
+    # its foreign-key column is still tracked as an ordinary field by
+    # `aggregate_fields`, mirroring how polymorphic / HABTM relations are dropped.
+    private def belongs_to_for(assoc)
+      { table_name: assoc.klass.collection_name.to_s, foreign_key: assoc.foreign_key }
+    rescue NameError, ::Mongoid::Errors::MongoidError => e
+      raise e unless @skip_unsupported
+
+      warn("exwiw: skip_unsupported: skipping belongs_to ':#{assoc.name}' that could not be resolved (#{e.class}: #{e.message.lines.first&.strip}); its foreign key '#{assoc.foreign_key}' is still kept as a field.")
+      nil
     end
 
     # Resolves the `embedded_in` config for an embedded model. Each embedded
@@ -196,14 +259,30 @@ module Exwiw
       # names exactly one parent collection + path, so this shape cannot be
       # represented; fail loudly with an actionable message instead of crashing.
       if assoc.polymorphic?
-        raise ArgumentError,
-              "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
-              "declares a polymorphic `embedded_in :#{assoc.name}`, which has no single embedding " \
-              "parent collection and cannot be expressed as an exwiw `embedded_in` config. " \
-              "Define the collection's config by hand, or make the relation non-polymorphic."
+        raise UnsupportedEmbedding.new(
+          "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
+          "declares a polymorphic `embedded_in :#{assoc.name}`, which has no single embedding " \
+          "parent collection and cannot be expressed as an exwiw `embedded_in` config. " \
+          "Define the collection's config by hand, or make the relation non-polymorphic.",
+          reason: "has a polymorphic embedded_in :#{assoc.name}",
+        )
       end
 
-      parent = assoc.klass
+      parent =
+        begin
+          assoc.klass
+        rescue NameError => e
+          # The embedding-parent class named by `class_name` (or inferred from
+          # the relation) does not exist — a stale/renamed parent. exwiw cannot
+          # name a parent collection it cannot resolve.
+          raise UnsupportedEmbedding.new(
+            "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
+            "declares `embedded_in :#{assoc.name}` whose parent class cannot be resolved " \
+            "(#{e.message.lines.first&.strip}). Fix the association's class_name, or define the " \
+            "collection's config by hand.",
+            reason: "has an embedded_in :#{assoc.name} whose parent class is unresolvable",
+          )
+        end
 
       # A self-referential / cyclic `embedded_in` — Mongoid's
       # `recursively_embeds_many` / `recursively_embeds_one` (which declare a
@@ -216,19 +295,47 @@ module Exwiw
       # `MongodbAdapter#dumpable?` (`!embedded?`) would silently never dump the
       # collection's root documents. Fail loudly instead.
       if parent.collection_name.to_s == model.collection_name.to_s
-        raise ArgumentError,
-              "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
-              "declares a self-referential (cyclic) `embedded_in :#{assoc.name}` that embeds the " \
-              "collection inside documents of its own type (e.g. `recursively_embeds_many` / " \
-              "`recursively_embeds_one`). " \
-              "exwiw represents a collection as either top-level or embedded, not both, so this " \
-              "cannot be expressed as an exwiw `embedded_in` config. Define the collection's config " \
-              "by hand."
+        raise UnsupportedEmbedding.new(
+          "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
+          "declares a self-referential (cyclic) `embedded_in :#{assoc.name}` that embeds the " \
+          "collection inside documents of its own type (e.g. `recursively_embeds_many` / " \
+          "`recursively_embeds_one`). " \
+          "exwiw represents a collection as either top-level or embedded, not both, so this " \
+          "cannot be expressed as an exwiw `embedded_in` config. Define the collection's config " \
+          "by hand.",
+          reason: "has a self-referential (cyclic) embedded_in :#{assoc.name}",
+        )
       end
 
       # `store_as` defaults to the relation name and is the actual document key
       # the subdocuments are stored under inside the immediate parent.
-      parent_relation = parent.relations[assoc.inverse.to_s]
+      parent_relation =
+        begin
+          parent.relations[assoc.inverse.to_s]
+        rescue ::Mongoid::Errors::MongoidError, NameError => e
+          # e.g. AmbiguousRelationship: the embedded class is embedded under
+          # several document keys in the parent (or otherwise has no single
+          # resolvable inverse), so exwiw cannot pick the one path it lives under.
+          raise UnsupportedEmbedding.new(
+            "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
+            "declares `embedded_in :#{assoc.name}` whose inverse on '#{parent.name}' is ambiguous " \
+            "or unresolvable (#{e.class}: #{e.message.lines.first&.strip}). Add an `inverse_of:` to " \
+            "disambiguate, or define the collection's config by hand.",
+            reason: "has an embedded_in :#{assoc.name} with an ambiguous/unresolvable inverse",
+          )
+        end
+
+      unless parent_relation
+        # `assoc.inverse` resolved to a name that is not an association on the
+        # parent (or to nothing), so there is no document key to embed under.
+        raise UnsupportedEmbedding.new(
+          "MongoidSchemaGenerator: '#{model.name}' (collection '#{model.collection_name}') " \
+          "declares `embedded_in :#{assoc.name}` but its inverse relation could not be located on " \
+          "'#{parent.name}' (the embedding document key is indeterminable). Add an `inverse_of:`, or " \
+          "define the collection's config by hand.",
+          reason: "has an embedded_in :#{assoc.name} whose inverse relation could not be located",
+        )
+      end
 
       { collection_name: parent.collection_name.to_s, path: parent_relation.store_as }
     end

--- a/lib/tasks/exwiw.rake
+++ b/lib/tasks/exwiw.rake
@@ -32,11 +32,17 @@ namespace :exwiw do
     end
 
     desc "Generate schema from a Mongoid application"
+    # Set EXWIW_SKIP_UNSUPPORTED=1 to keep generation going past constructs exwiw
+    # cannot represent (an unresolvable `belongs_to`, or a polymorphic / cyclic /
+    # unresolvable `embedded_in`): the unresolvable belongs_to is skipped and an
+    # unrepresentable embedded collection is emitted as `ignore: true` with a
+    # `comment`, each warned to stderr, instead of aborting the whole run.
     task generate_mongoid: :environment do
       require "exwiw"
 
       Exwiw::MongoidSchemaGenerator.from_rails_application(
         output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw",
+        skip_unsupported: ENV["EXWIW_SKIP_UNSUPPORTED"] == "1",
       ).generate!
     end
   end

--- a/script/mongoid_models.rb
+++ b/script/mongoid_models.rb
@@ -407,6 +407,63 @@ module MongoidDummy
     recursively_embeds_one
   end
 
+  # A referenced `belongs_to` whose target class does not exist (e.g. pointing at
+  # a model removed long ago). Mongoid resolves association classes lazily, so
+  # the model itself loads fine; only `assoc.klass` — which the generator calls
+  # to derive the target collection — raises a NameError. By default that aborts
+  # the run; under `skip_unsupported` the generator skips the relation while
+  # still tracking the auto-added `ghost_id` foreign-key field. Kept OUT of
+  # `MODELS`/`SEED` and exercised in isolation.
+  class StaleReferencer
+    include Mongoid::Document
+    store_in collection: "stale_referencers"
+
+    field :note, type: String
+
+    # No class_name, so Mongoid infers a `Ghost` class that does not exist
+    # (mirroring a real stale `belongs_to :delivery_method` left behind after its
+    # model was removed). The auto-added `ghost_id` field still rides along.
+    belongs_to :ghost
+  end
+
+  # An embedded document whose embedding-parent class does not exist (a renamed /
+  # removed parent named by `class_name`). The `embedded_in` association loads
+  # lazily, but `assoc.klass` raises a NameError, which `embedded_in_for`
+  # surfaces as an UnsupportedEmbedding. By default that aborts the run; under
+  # `skip_unsupported` the collection is emitted as `ignore: true`. Kept OUT of
+  # `MODELS`/`SEED` and exercised in isolation.
+  class OrphanEmbedded
+    include Mongoid::Document
+    store_in collection: "orphan_embeddeds"
+
+    field :note, type: String
+
+    embedded_in :ghost_parent, class_name: "MongoidDummy::GhostParent"
+  end
+
+  # A parent that embeds the SAME child class under multiple document keys
+  # without `inverse_of:`, so the child's `embedded_in` has no single resolvable
+  # inverse. Mongoid raises `AmbiguousRelationship` when resolving
+  # `assoc.inverse`, which `embedded_in_for` surfaces as an UnsupportedEmbedding
+  # (exwiw cannot pick which of the several paths the child lives under). Kept
+  # OUT of `MODELS`/`SEED` and exercised in isolation.
+  class AmbiguousParent
+    include Mongoid::Document
+    store_in collection: "ambiguous_parents"
+
+    embeds_many :primary_children, class_name: "MongoidDummy::AmbiguousChild"
+    embeds_many :secondary_children, class_name: "MongoidDummy::AmbiguousChild"
+  end
+
+  class AmbiguousChild
+    include Mongoid::Document
+    store_in collection: "ambiguous_children"
+
+    field :value, type: String
+
+    embedded_in :ambiguous_parent, class_name: "MongoidDummy::AmbiguousParent"
+  end
+
   # All concrete document models in this dummy app, in a deterministic order.
   #
   # Mongoid only registers the *base* class of an inheritance hierarchy in

--- a/spec/mongoid_schema_generator_spec.rb
+++ b/spec/mongoid_schema_generator_spec.rb
@@ -277,6 +277,88 @@ module Exwiw
       end
     end
 
+    describe "#build_collections with skip_unsupported: true" do
+      def build(models)
+        described_class.new(models: models, output_dir: output_dir, skip_unsupported: true).build_collections
+      end
+
+      it "skips an unresolvable belongs_to but keeps its foreign-key field instead of raising" do
+        # StaleReferencer#ghost points at a class that does not exist, so
+        # `assoc.klass` raises NameError. With skip_unsupported the relation is
+        # dropped from belongs_tos while the auto-added `ghost_id` field survives,
+        # mirroring how polymorphic / HABTM relations are handled.
+        config = nil
+        expect { config = build([MongoidDummy::StaleReferencer]).first }
+          .to output(/skipping belongs_to ':ghost'/).to_stderr
+        expect(config.belongs_tos).to be_empty
+        expect(config.fields.map(&:name)).to include("ghost_id")
+        expect(config.ignore).to be_nil
+      end
+
+      it "emits a polymorphic embedded_in collection as ignore:true with a comment instead of raising" do
+        config = nil
+        expect { config = build([MongoidDummy::PolymorphicAddress]).first }
+          .to output(/polymorphic embedded_in :addressable/).to_stderr
+        expect(config.name).to eq("polymorphic_addresses")
+        expect(config.ignore).to eq(true)
+        expect(config.embedded_in).to be_nil
+        expect(config.belongs_tos).to be_empty
+        expect(config.comment).to match(/polymorphic embedded_in :addressable/)
+      end
+
+      it "emits a self-referential (cyclic) embedded_in collection as ignore:true instead of raising" do
+        config = nil
+        expect { config = build([MongoidDummy::TreeNode]).first }
+          .to output(/self-referential \(cyclic\) embedded_in/).to_stderr
+        expect(config.name).to eq("tree_nodes")
+        expect(config.ignore).to eq(true)
+        expect(config.embedded_in).to be_nil
+        expect(config.comment).to match(/cyclic/)
+      end
+
+      it "emits an embedded_in collection with an unresolvable parent class as ignore:true instead of raising" do
+        config = nil
+        expect { config = build([MongoidDummy::OrphanEmbedded]).first }
+          .to output(/parent class is unresolvable/).to_stderr
+        expect(config.name).to eq("orphan_embeddeds")
+        expect(config.ignore).to eq(true)
+        expect(config.embedded_in).to be_nil
+        expect(config.comment).to match(/unresolvable/)
+      end
+
+      it "emits an embedded_in collection with an ambiguous inverse as ignore:true instead of raising" do
+        # AmbiguousChild is embedded under two keys in AmbiguousParent without
+        # inverse_of, so Mongoid raises AmbiguousRelationship resolving the
+        # inverse. exwiw cannot pick the single path, so under skip_unsupported it
+        # marks the collection ignore:true rather than aborting.
+        config = nil
+        expect { config = build([MongoidDummy::AmbiguousChild]).first }
+          .to output(%r{ambiguous/unresolvable inverse}).to_stderr
+        expect(config.name).to eq("ambiguous_children")
+        expect(config.ignore).to eq(true)
+        expect(config.embedded_in).to be_nil
+        expect(config.comment).to match(/ambiguous/)
+      end
+
+      it "still raises by default (skip_unsupported off) on an ambiguous embedded_in inverse" do
+        expect {
+          described_class.new(models: [MongoidDummy::AmbiguousChild], output_dir: output_dir).build_collections
+        }.to raise_error(MongoidSchemaGenerator::UnsupportedEmbedding, /ambiguous or unresolvable/)
+      end
+
+      it "still raises by default (skip_unsupported off) on an unresolvable belongs_to" do
+        expect {
+          described_class.new(models: [MongoidDummy::StaleReferencer], output_dir: output_dir).build_collections
+        }.to raise_error(NameError, /uninitialized constant/)
+      end
+
+      it "still raises by default (skip_unsupported off) on an unresolvable embedded_in parent" do
+        expect {
+          described_class.new(models: [MongoidDummy::OrphanEmbedded], output_dir: output_dir).build_collections
+        }.to raise_error(MongoidSchemaGenerator::UnsupportedEmbedding, /parent class cannot be resolved/)
+      end
+    end
+
     describe "#generate!" do
       it "writes one JSON file per collection" do
         described_class.new(models: models, output_dir: output_dir).generate!


### PR DESCRIPTION
## 概要

`MongoidSchemaGenerator` に opt-in の `skip_unsupported:` モードを追加する。
rake タスクからは `EXWIW_SKIP_UNSUPPORTED=1 bundle exec rake exwiw:schema:generate_mongoid` で有効化できる。

有効時は、exwiw が表現できない構造に遭遇しても生成を中断せず処理を継続する。大規模アプリで設定をブートストラップする際に、一部のレガシー/polymorphic なコレクションが全体を止めてしまうのを避けられる。

## 変更内容

- **解決できない `belongs_to`**（対象クラスが既に存在しない、削除済みモデルへの stale な関連）: 外部キーのフィールドは残したまま関連自体をスキップし、stderr に警告を出す（polymorphic / HABTM と同じ扱い）。
- **表現できない `embedded_in`**（polymorphic / 自己参照（循環） / 親クラス未解決 / inverse が曖昧）: コレクションを `ignore: true` のトップレベル設定として出力し、理由を `comment` に記録する。自前のコレクションとして誤って dump されるのを防ぐ。実際に dump/mask したい場合は `embedded_in` 設定を手書きする。
- `MongodbCollectionConfig` にコレクションレベルの `comment` 属性を追加。再生成時に field / belongs_to の `comment` と同様に保持される。
- デフォルト（opt-in しない場合）は従来どおり fail-loud なので、既存の挙動は変わらない。

## テスト

- `skip_unsupported: true` での各ケース（unresolvable belongs_to / polymorphic / cyclic / unresolvable parent / ambiguous inverse）を追加
- `skip_unsupported` off（デフォルト）で従来どおり raise することも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
