### PR TITLE
fix: pass --no-tablespaces to mysqldump for RDS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MySQL: `mysqldump` no longer fails with `Access denied; you need (at least one of) the PROCESS privilege(s)` on RDS and other managed MySQL instances where the DB user lacks `PROCESS`. The `--no-tablespaces` flag is now always passed, skipping the tablespace query that requires the privilege. Both MySQL and MariaDB support the flag.
+
 ## [0.4.2] - 2026-06-05
 
 ### Fixed

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -55,6 +55,7 @@ module Exwiw
           '--skip-add-drop-table',
           '--skip-comments',
           '--skip-set-charset',
+          '--no-tablespaces',
           *gtid_flags,
           '--compact',
           @connection_config.database_name,

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -55,7 +55,7 @@ module Exwiw
           '--skip-add-drop-table',
           '--skip-comments',
           '--skip-set-charset',
-          '--no-tablespaces',
+          '--no-tablespaces', # skip tablespace query that requires PROCESS privilege (unavailable on managed MySQL like RDS)
           *gtid_flags,
           '--compact',
           @connection_config.database_name,

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -53,6 +53,12 @@ module Exwiw
             adapter.dump_schema(tables, schema_path)
             expect(@captured_cmd).not_to include('--set-gtid-purged=OFF')
           end
+
+          it "includes --no-tablespaces" do
+            tables = [shops_table(adapter_name)]
+            adapter.dump_schema(tables, schema_path)
+            expect(@captured_cmd).to include('--no-tablespaces')
+          end
         end
 
         context "when mysqldump is MySQL" do
@@ -75,6 +81,12 @@ module Exwiw
             tables = [shops_table(adapter_name)]
             adapter.dump_schema(tables, schema_path)
             expect(@captured_cmd).to include('--set-gtid-purged=OFF')
+          end
+
+          it "includes --no-tablespaces" do
+            tables = [shops_table(adapter_name)]
+            adapter.dump_schema(tables, schema_path)
+            expect(@captured_cmd).to include('--no-tablespaces')
           end
         end
 


### PR DESCRIPTION
- resolves https://github.com/heyinc/storesinc-tech-infra/issues/863

## Summary

- RDS の DB ユーザーに PROCESS 権限がなく、mysqldump が tablespace 情報の取得時にエラーになる問題を修正
- `--no-tablespaces` フラグを常時付与（MySQL / MariaDB 両対応、分岐不要）

## Test plan

- [x] CI rspec 通過（`--no-tablespaces` が MariaDB / MySQL 両コンテキストでコマンドに含まれることを検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)