### PR TITLE
fix: backtick-quote table/column names in MySQL INSERT statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MySQL: INSERT statements now backtick-quote table and column names. Previously, columns whose name is a MySQL reserved word (e.g. `key` in `active_storage_blobs`) caused syntax errors on restore. ([#83](https://github.com/heyinc/exwiw/pull/83))
+
 ## [0.4.4] - 2026-06-05
 
 ### Fixed

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -111,10 +111,10 @@ module Exwiw
         values = value_list.join(",\n")
 
         if table.rails_managed?
-          "INSERT INTO #{table_name} VALUES\n#{values};"
+          "INSERT INTO `#{table_name}` VALUES\n#{values};"
         else
-          column_names = table.columns.map(&:name).join(', ')
-          "INSERT INTO #{table_name} (#{column_names}) VALUES\n#{values};"
+          column_names = table.columns.map { |c| "`#{c.name}`" }.join(', ')
+          "INSERT INTO `#{table_name}` (#{column_names}) VALUES\n#{values};"
         end
       end
 

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -338,7 +338,7 @@ module Exwiw
 
           it "returns correct bulk insert sql" do
             expect(bulk_insert_sql.strip).to eq(<<~SQL.strip)
-              INSERT INTO shops (id, name, updated_at, created_at) VALUES
+              INSERT INTO `shops` (`id`, `name`, `updated_at`, `created_at`) VALUES
               ('1', 'Shop 1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
               ('2', 'Shop 2', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
               ('3', 'Shop 3', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');
@@ -359,7 +359,7 @@ module Exwiw
 
           it "returns correct bulk insert sql" do
             expect(bulk_insert_sql.strip).to eq(<<~SQL.strip)
-              INSERT INTO shops (id, name, updated_at, created_at) VALUES
+              INSERT INTO `shops` (`id`, `name`, `updated_at`, `created_at`) VALUES
               ('1', 'Shop'' 1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
               ('2', 'Shop 2', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
               ('3', 'Shop 3', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');

--- a/spec/insert_output_snapshots/mysql/insert-001-shops.sql
+++ b/spec/insert_output_snapshots/mysql/insert-001-shops.sql
@@ -1,4 +1,4 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO shops (id, name, updated_at, created_at) VALUES
+INSERT INTO `shops` (`id`, `name`, `updated_at`, `created_at`) VALUES
 ('1', 'Shop 1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;

--- a/spec/insert_output_snapshots/mysql/insert-002-system_announcements.sql
+++ b/spec/insert_output_snapshots/mysql/insert-002-system_announcements.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO system_announcements (id, title, content, updated_at, created_at) VALUES
+INSERT INTO `system_announcements` (`id`, `title`, `content`, `updated_at`, `created_at`) VALUES
 ('1', 'Announcement 1', 'This is the content of announcement 1.', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('2', 'Announcement 2', 'This is the content of announcement 2.', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('3', 'Announcement 3', 'This is the content of announcement 3.', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');

--- a/spec/insert_output_snapshots/mysql/insert-003-products.sql
+++ b/spec/insert_output_snapshots/mysql/insert-003-products.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO products (id, name, price, shop_id, updated_at, created_at) VALUES
+INSERT INTO `products` (`id`, `name`, `price`, `shop_id`, `updated_at`, `created_at`) VALUES
 ('1', 'Product 1', '10.00', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('2', 'Product 2', '20.00', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('3', 'Product 3', '30.00', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');

--- a/spec/insert_output_snapshots/mysql/insert-004-users.sql
+++ b/spec/insert_output_snapshots/mysql/insert-004-users.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO users (id, name, email, shop_id, updated_at, created_at) VALUES
+INSERT INTO `users` (`id`, `name`, `email`, `shop_id`, `updated_at`, `created_at`) VALUES
 ('1', 'masked1', 'masked1@example.com', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('2', 'masked2', 'masked2@example.com', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000');
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;

--- a/spec/insert_output_snapshots/mysql/insert-005-orders.sql
+++ b/spec/insert_output_snapshots/mysql/insert-005-orders.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO orders (id, shop_id, user_id, updated_at, created_at) VALUES
+INSERT INTO `orders` (`id`, `shop_id`, `user_id`, `updated_at`, `created_at`) VALUES
 ('3', '1', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('4', '1', '2', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('5', '1', '2', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),

--- a/spec/insert_output_snapshots/mysql/insert-006-order_items.sql
+++ b/spec/insert_output_snapshots/mysql/insert-006-order_items.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO order_items (id, quantity, order_id, product_id, updated_at, created_at) VALUES
+INSERT INTO `order_items` (`id`, `quantity`, `order_id`, `product_id`, `updated_at`, `created_at`) VALUES
 ('3', '1', '3', '3', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('4', '1', '4', '1', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('5', '1', '5', '2', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),

--- a/spec/insert_output_snapshots/mysql/insert-007-transactions.sql
+++ b/spec/insert_output_snapshots/mysql/insert-007-transactions.sql
@@ -1,5 +1,5 @@
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
-INSERT INTO transactions (id, type, amount, order_id, updated_at, created_at) VALUES
+INSERT INTO `transactions` (`id`, `type`, `amount`, `order_id`, `updated_at`, `created_at`) VALUES
 ('3', 'PaymentTransaction', '30.00', '3', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('4', 'PaymentTransaction', '10.00', '4', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),
 ('5', 'PaymentTransaction', '20.00', '5', '2025-01-01 00:00:00.000000', '2025-01-01 00:00:00.000000'),


### PR DESCRIPTION
- resolves https://github.com/heyinc/storesinc-tech-infra/issues/863


## Summary

- MySQL の予約語（例: `active_storage_blobs` の `key` カラム）がカラム名に使われている場合、INSERT 文が構文エラーになる問題を修正
- `to_bulk_insert` でテーブル名・カラム名をバッククォートで囲むように変更（`mysqldump` と同じ挙動）

## Test plan

- [x] `bundle exec rspec spec/adapter/mysql_adapter_spec.rb`
- [x] `bundle exec rspec spec/insert_output_snapshot_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)