### PR TITLE
chore: 出力先を exwiw/schema に変更し環境変数を EXWIW_SCHEMA_DIR_PATH にリネーム

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `schema:generate`, `schema:tidy`, and `schema:generate_mongoid` now default their output directory to `exwiw/config` (previously `exwiw`) when `OUTPUT_DIR_PATH` is unset. This keeps generated schema config under a dedicated `config/` subdirectory, leaving `exwiw/` free for other artifacts (hooks, dumps). Existing repositories that keep config flat in `exwiw/` should either move those files to `exwiw/config/` or set `OUTPUT_DIR_PATH=exwiw` to preserve the old layout; otherwise a no-`OUTPUT_DIR_PATH` `generate` run will write a second copy into `exwiw/config/` and leave the old `exwiw/*.json` stale. The `export`/`explain` CLI is unaffected (`--config-dir` is still required and has no default), but examples now point at `exwiw/config`.
+
 ## [0.4.11] - 2026-06-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **BREAKING**: `schema:generate`, `schema:tidy`, and `schema:generate_mongoid` now default their output directory to `exwiw/config` (previously `exwiw`) when `OUTPUT_DIR_PATH` is unset. This keeps generated schema config under a dedicated `config/` subdirectory, leaving `exwiw/` free for other artifacts (hooks, dumps). Existing repositories that keep config flat in `exwiw/` should either move those files to `exwiw/config/` or set `OUTPUT_DIR_PATH=exwiw` to preserve the old layout; otherwise a no-`OUTPUT_DIR_PATH` `generate` run will write a second copy into `exwiw/config/` and leave the old `exwiw/*.json` stale. The `export`/`explain` CLI is unaffected (`--config-dir` is still required and has no default), but examples now point at `exwiw/config`.
+- **BREAKING**: the env var that overrides where `schema:generate`, `schema:tidy`, and `schema:generate_mongoid` write their config has been renamed from `OUTPUT_DIR_PATH` to `EXWIW_SCHEMA_DIR_PATH`, and the default output directory is now `exwiw/schema` (previously `exwiw`). The new name disambiguates it from the dump-side `--output-dir`, and the dedicated `schema/` subdirectory leaves `exwiw/` free for other artifacts (hooks, dumps). `OUTPUT_DIR_PATH` is no longer read. Existing repositories should set `EXWIW_SCHEMA_DIR_PATH` (e.g. `EXWIW_SCHEMA_DIR_PATH=exwiw` to preserve the old flat layout) and/or move their config under `exwiw/schema/`; otherwise a `generate` run will write a fresh copy into `exwiw/schema/` and leave the old files stale. The `export`/`explain` CLI is unaffected (`--config-dir` is still required and has no default), but examples now point at `exwiw/schema`.
 
 ## [0.4.11] - 2026-06-15
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ exwiw \
   --port=3306 \
   --user=reader \
   --database=app_production \
-  --config-dir=exwiw \
+  --config-dir=exwiw/config \
   --target-table=shops \
   --ids=1 \ # comma separated ids
   --output-dir=dump \
@@ -91,7 +91,7 @@ exwiw \
   --port=5432 \
   --user=reader \
   --database=app_production \
-  --config-dir=exwiw \
+  --config-dir=exwiw/config \
   --output-dir=dump
 ```
 
@@ -123,7 +123,7 @@ exwiw explain \
   --adapter=postgresql \
   --host=localhost --port=5432 --user=reader \
   --database=app_production \
-  --config-dir=exwiw \
+  --config-dir=exwiw/config \
   --target-table=shops --ids=1
 ```
 
@@ -134,11 +134,11 @@ The `--output-dir`, `--output-format`, `--insert-only`, and `--after-insert-hook
 The config generator is provided as a Rake task.
 
 ```bash
-# generate table schema under exwiw/
+# generate table schema under exwiw/config/
 bundle exec rake exwiw:schema:generate
 ```
 
-By default, the schema files will be saved in the `exwiw` directory. You can specify a different output directory by setting the `OUTPUT_DIR_PATH` environment variable:
+By default, the schema files will be saved in the `exwiw/config` directory. You can specify a different output directory by setting the `OUTPUT_DIR_PATH` environment variable:
 
 ```sh
 OUTPUT_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
@@ -166,7 +166,7 @@ It respects `OUTPUT_DIR_PATH` and the per-database subdirectory layout in the sa
 If the application uses Rails' multiple-database support (`connects_to`), `schema:generate` buckets models by the database they connect to and writes each database's config files into its own subdirectory of the output directory, named after the database config name (`primary`, `analytics`, ...):
 
 ```
-exwiw/
+exwiw/config/
   primary/
     shops.json
     users.json

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ exwiw \
   --port=3306 \
   --user=reader \
   --database=app_production \
-  --config-dir=exwiw/config \
+  --config-dir=exwiw/schema \
   --target-table=shops \
   --ids=1 \ # comma separated ids
   --output-dir=dump \
@@ -91,7 +91,7 @@ exwiw \
   --port=5432 \
   --user=reader \
   --database=app_production \
-  --config-dir=exwiw/config \
+  --config-dir=exwiw/schema \
   --output-dir=dump
 ```
 
@@ -123,7 +123,7 @@ exwiw explain \
   --adapter=postgresql \
   --host=localhost --port=5432 --user=reader \
   --database=app_production \
-  --config-dir=exwiw/config \
+  --config-dir=exwiw/schema \
   --target-table=shops --ids=1
 ```
 
@@ -134,14 +134,14 @@ The `--output-dir`, `--output-format`, `--insert-only`, and `--after-insert-hook
 The config generator is provided as a Rake task.
 
 ```bash
-# generate table schema under exwiw/config/
+# generate table schema under exwiw/schema/
 bundle exec rake exwiw:schema:generate
 ```
 
-By default, the schema files will be saved in the `exwiw/config` directory. You can specify a different output directory by setting the `OUTPUT_DIR_PATH` environment variable:
+By default, the schema files will be saved in the `exwiw/schema` directory. You can specify a different output directory by setting the `EXWIW_SCHEMA_DIR_PATH` environment variable:
 
 ```sh
-OUTPUT_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
+EXWIW_SCHEMA_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
 ```
 
 #### Tidying stale config (`schema:tidy`)
@@ -159,14 +159,14 @@ bundle exec rake exwiw:schema:tidy
 
 Because it reads the database directly, a table that still exists in the database but has lost (or never had) an ActiveRecord model is **kept** — only a table that is genuinely gone is removed. (This is the deliberate counterpart to `generate`, which is model-driven and only ever adds what the models know about.)
 
-It respects `OUTPUT_DIR_PATH` and the per-database subdirectory layout in the same way as `schema:generate`. Unlike `generate`, `tidy` never adds or regenerates entries — every surviving table/column (including hand-edited `comment` / `ignore` / `replace_with`) is left untouched, so it is safe to run on a customized config. The task prints which tables and columns it removed (or that the config was already tidy). Stale `belongs_tos` are not pruned by `tidy`; rerun `schema:generate` to refresh those.
+It respects `EXWIW_SCHEMA_DIR_PATH` and the per-database subdirectory layout in the same way as `schema:generate`. Unlike `generate`, `tidy` never adds or regenerates entries — every surviving table/column (including hand-edited `comment` / `ignore` / `replace_with`) is left untouched, so it is safe to run on a customized config. The task prints which tables and columns it removed (or that the config was already tidy). Stale `belongs_tos` are not pruned by `tidy`; rerun `schema:generate` to refresh those.
 
 #### Multiple databases
 
 If the application uses Rails' multiple-database support (`connects_to`), `schema:generate` buckets models by the database they connect to and writes each database's config files into its own subdirectory of the output directory, named after the database config name (`primary`, `analytics`, ...):
 
 ```
-exwiw/config/
+exwiw/schema/
   primary/
     shops.json
     users.json

--- a/lib/tasks/exwiw.rake
+++ b/lib/tasks/exwiw.rake
@@ -7,7 +7,7 @@ namespace :exwiw do
       require "exwiw"
 
       Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
+        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
       ).generate!
     end
 
@@ -16,7 +16,7 @@ namespace :exwiw do
       require "exwiw"
 
       result = Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
+        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
       ).tidy!
 
       if result.empty?
@@ -47,7 +47,7 @@ namespace :exwiw do
       require "exwiw"
 
       Exwiw::MongoidSchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
+        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
         skip_unsupported: ENV["EXWIW_SKIP_UNSUPPORTED"] == "1",
       ).generate!
     end

--- a/lib/tasks/exwiw.rake
+++ b/lib/tasks/exwiw.rake
@@ -7,7 +7,7 @@ namespace :exwiw do
       require "exwiw"
 
       Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw",
+        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
       ).generate!
     end
 
@@ -16,7 +16,7 @@ namespace :exwiw do
       require "exwiw"
 
       result = Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw",
+        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
       ).tidy!
 
       if result.empty?
@@ -47,7 +47,7 @@ namespace :exwiw do
       require "exwiw"
 
       Exwiw::MongoidSchemaGenerator.from_rails_application(
-        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw",
+        output_dir: ENV["OUTPUT_DIR_PATH"] || "exwiw/config",
         skip_unsupported: ENV["EXWIW_SKIP_UNSUPPORTED"] == "1",
       ).generate!
     end


### PR DESCRIPTION
## 概要

schema 生成系 rake タスクのデフォルト出力先を `exwiw/schema` に変更し、出力先を上書きする環境変数を `OUTPUT_DIR_PATH` → `EXWIW_SCHEMA_DIR_PATH` にリネームする。

対象タスク:
- `exwiw:schema:generate`
- `exwiw:schema:tidy`
- `exwiw:schema:generate_mongoid`

### ねらい
- 生成された schema 設定を `schema/` サブディレクトリ配下に集約し、`exwiw/` を hooks や dump など他の成果物用に空けておく
- `OUTPUT_DIR_PATH` は dump 側の `--output-dir` と名前が紛らわしかったため、用途が明確な `EXWIW_SCHEMA_DIR_PATH` に改名

## 破壊的変更

**BREAKING**:
- 出力先デフォルトが `exwiw` → `exwiw/schema` に変更
- `OUTPUT_DIR_PATH` は読まれなくなる（`EXWIW_SCHEMA_DIR_PATH` に置き換え）

移行方法:
- `EXWIW_SCHEMA_DIR_PATH` を設定する（従来の flat レイアウトを維持するなら `EXWIW_SCHEMA_DIR_PATH=exwiw`）
- もしくは既存設定を `exwiw/schema/` 配下へ移動する

未対応のまま `generate` を実行すると `exwiw/schema/` に新規生成され、旧ファイルが stale になる点に注意。

`export` / `explain` CLI は `--config-dir` 必須・デフォルト無しのままなので挙動への影響なし（README の例のみ `exwiw/schema` に統一）。

## 変更内容

- `lib/tasks/exwiw.rake`: 3 タスクのデフォルトを `ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema"` に
- `README.md`: Generator のデフォルト説明・env 例・複数 DB ツリー例・`--config-dir` の例を更新
- `CHANGELOG.md`: `[Unreleased]` の BREAKING 注記を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)