### PR TITLE
feat: require scope_exempt for unrelated tables in --target-table mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: in `--target-table` mode (SQL adapters), a table with no relation to the target now aborts the run unless it is explicitly `scope_exempt: true`.** Previously a table that has no `belongs_to` path to the `--target-table` and is not referenced by any extractable child produced a SELECT with no WHERE and was dumped **in full across every scope** — easy to miss, and a cross-scope data-exposure risk for a table that was simply forgotten. exwiw now refuses to start and lists the offending table(s), mirroring the strict pre-flight already used by `--scope-column` mode. To dump a genuine reference/master table in full, mark it `scope_exempt: true` (the same user-owned key already honored in scope-column mode); to skip it, set `ignore: true`. Rails-managed tables (`schema_migrations`, `ar_internal_metadata`) are treated as exempt automatically. The check also runs under `exwiw explain`. This only affects `--target-table` mode; `--scope-column` mode and the no-target dump-all mode are unchanged, and MongoDB is unaffected (it already constrains belongs_to-less collections separately and has no `scope_exempt` key). Existing schemas that relied on the silent full dump must add `scope_exempt: true` to those tables.
+
 ## [0.6.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ exwiw \
 
 By default `--ids` are matched against the target table's primary key. `--ids-column=COLUMN` matches them against a different column instead (e.g. `--target-table=users --ids=alice@example.com --ids-column=email`). Related tables are still extracted correctly: their foreign keys are resolved through the target via a subquery (`WHERE fk IN (SELECT pk FROM target WHERE COLUMN IN (...))`), so only the target table's filter column changes. This is the SQL-adapter counterpart of the mongodb `--ids-field`; the two are mutually exclusive and each is rejected by the other adapter family. Note: if `COLUMN` is itself masked, re-running `delete-*` against an already-imported (masked) dump won't match, so prefer a stable natural key.
 
+In `--target-table` mode, every other table must be reachable from the target — directly or transitively via `belongs_to`, or by being referenced by an extractable child. A table with **no** such relation has no WHERE clause and would otherwise be dumped in full across every scope, so exwiw aborts before extracting and lists the offending table(s). To dump a genuine reference/master table in full anyway, mark it [`scope_exempt: true`](#scope_exempt-intentional-full-dump); to leave it out, set `ignore: true`. Rails-managed tables (`schema_migrations`, `ar_internal_metadata`) are exempt automatically. (This check is SQL-only and does not apply to the no-target dump-all mode below or to MongoDB.)
+
 When `--target-table` and `--ids` are omitted, exwiw dumps all tables defined in `--schema-dir`:
 
 ```bash
@@ -190,8 +192,11 @@ opt out of the strict check and be exported in full:
 }
 ```
 
-Rails-managed tables (`schema_migrations`, `ar_internal_metadata`) are treated as
-exempt automatically.
+`scope_exempt` is honored in **both** modes: in scope-column mode it opts a table
+out of the shared-column filter, and in `--target-table` mode it opts a table with
+no relation to the target out of the "would be dumped in full" abort. Rails-managed
+tables (`schema_migrations`, `ar_internal_metadata`) are treated as exempt
+automatically in both.
 
 #### Per-table `scope_column` override
 

--- a/e2e/mysql-schema/system_announcements.json
+++ b/e2e/mysql-schema/system_announcements.json
@@ -2,6 +2,7 @@
   "name": "system_announcements",
   "primary_key": "id",
   "belongs_tos": [],
+  "scope_exempt": true,
   "columns": [{
     "name": "id"
   }, {

--- a/e2e/postgresql-schema/system_announcements.json
+++ b/e2e/postgresql-schema/system_announcements.json
@@ -2,6 +2,7 @@
   "name": "system_announcements",
   "primary_key": "id",
   "belongs_tos": [],
+  "scope_exempt": true,
   "columns": [{
     "name": "id"
   }, {

--- a/e2e/sqlite-schema/system_announcements.json
+++ b/e2e/sqlite-schema/system_announcements.json
@@ -2,6 +2,7 @@
   "name": "system_announcements",
   "primary_key": "id",
   "belongs_tos": [],
+  "scope_exempt": true,
   "columns": [{
     "name": "id"
   }, {

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -28,6 +28,7 @@ module Exwiw
 
       dumpable_configs = configs.select { |c| adapter.dumpable?(c) }
       QueryAstBuilder.validate_scope!(dumpable_configs, table_by_name, @dump_target, @logger)
+      QueryAstBuilder.validate_target_scope!(dumpable_configs, table_by_name, @dump_target, @logger)
 
       @logger.debug("Determining table processing order...")
       ordered_table_names = DetermineTableProcessingOrder.run(dumpable_configs, logger: @logger)

--- a/lib/exwiw/query_ast_builder.rb
+++ b/lib/exwiw/query_ast_builder.rb
@@ -34,6 +34,39 @@ module Exwiw
             "column name differs on that table)."
     end
 
+    # Strict pre-flight for target-table mode: abort if any extractable table has
+    # no relation to the dump target and would therefore be selected with no
+    # WHERE (a full-table dump across every scope — see the "no relation -> dump
+    # all" case in #run). Such a table must opt in explicitly with `scope_exempt:
+    # true` (rails-managed tables are exempt automatically), so a genuine
+    # reference/master table is dumped in full only on purpose. No-op outside
+    # target-table mode (scope-column mode is covered by validate_scope!).
+    # `tables` is the set of dumpable configs (ignore:true tables are skipped —
+    # they are not extracted). Configs whose adapter does not support
+    # `scope_exempt` (e.g. MongoDB) are left alone.
+    def self.validate_target_scope!(tables, table_by_name, dump_target, logger)
+      return if dump_target.table_name.nil?
+      return unless dump_target.scope_column.nil?
+
+      unscoped =
+        tables.reject(&:ignore).select do |table|
+          next false unless table.respond_to?(:scope_exempt)
+          next false if table.name == dump_target.table_name
+          next false if table.scope_exempt || table.rails_managed?
+
+          query = run(table.name, table_by_name, dump_target, logger)
+          query.where_clauses.empty? && query.join_clauses.empty?
+        end
+      return if unscoped.empty?
+
+      names = unscoped.map(&:name).sort.join(", ")
+      raise ArgumentError,
+            "--target-table '#{dump_target.table_name}': #{unscoped.size} table(s) have no " \
+            "relation to it and would be dumped in full (a no-WHERE SELECT across every scope): " \
+            "#{names}. For each, add `scope_exempt: true` to export it in full, or set " \
+            "`ignore: true` to skip it."
+    end
+
     attr_reader :table_name, :table_by_name, :dump_target
 
     def initialize(table_name, table_by_name, dump_target, logger, allow_reverse: true, allow_forward: true)

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -42,6 +42,9 @@ module Exwiw
       # Scope-column mode: abort if any extractable table cannot be scoped (no-op
       # otherwise). Done before extraction so nothing is dumped if it would leak.
       QueryAstBuilder.validate_scope!(dumpable_configs, table_by_name, @dump_target, @logger)
+      # Target-table mode: abort if any extractable table has no relation to the
+      # target and would be dumped in full unless explicitly `scope_exempt: true`.
+      QueryAstBuilder.validate_target_scope!(dumpable_configs, table_by_name, @dump_target, @logger)
 
       @logger.info("Determining table processing order...")
       ordered_table_names = DetermineTableProcessingOrder.run(dumpable_configs, logger: @logger)

--- a/lib/exwiw/table_config.rb
+++ b/lib/exwiw/table_config.rb
@@ -26,16 +26,19 @@ module Exwiw
     attribute :columns, array(TableColumn), default: []
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
     attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
-    # Scope-column mode only (see Exwiw::DumpTarget#scope_column). Both are
-    # user-configured and never emitted by the schema generators.
+    # Both are user-configured and never emitted by the schema generators.
     #
     # `scope_exempt: true` exports the whole table without scope filtering — the
     # explicit, auditable escape hatch for genuine reference/master tables under
-    # the strict "every table must be scopable" rule.
+    # the strict "every table must be scopable" rule. It is honored in both
+    # modes: in scope-column mode (see Exwiw::DumpTarget#scope_column) it opts a
+    # table out of the shared-column filter, and in target-table mode it opts a
+    # table with no relation to the target out of the "would be dumped in full"
+    # abort (rails-managed tables are treated as exempt automatically in both).
     #
-    # `scope_column` overrides the physical column this table is filtered on when
-    # it differs from the global `--scope-column` name (same scope value, just a
-    # different column name on this table).
+    # `scope_column` (scope-column mode only) overrides the physical column this
+    # table is filtered on when it differs from the global `--scope-column` name
+    # (same scope value, just a different column name on this table).
     attribute :scope_exempt, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
     attribute :scope_column, optional(String), skip_serializing_if_nil: true
 

--- a/spec/explain_runner_spec.rb
+++ b/spec/explain_runner_spec.rb
@@ -98,5 +98,20 @@ module Exwiw
         expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked ignore:true/)
       end
     end
+
+    describe '#run when a table has no relation to --target-table' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+      before do
+        FileUtils.cp('e2e/sqlite-schema/shops.json', File.join(schema_dir, 'shops.json'))
+        announcements = JSON.parse(File.read('e2e/sqlite-schema/system_announcements.json'))
+        announcements.delete('scope_exempt')
+        File.write(File.join(schema_dir, 'system_announcements.json'), JSON.dump(announcements))
+      end
+
+      it 'raises ArgumentError before explaining' do
+        expect { runner.run }.to raise_error(ArgumentError, /system_announcements.*scope_exempt: true/m)
+      end
+    end
   end
 end

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -818,4 +818,83 @@ RSpec.describe Exwiw::QueryAstBuilder do
       )
     end
   end
+
+  describe '.validate_target_scope!' do
+    let(:logger) { Logger.new(nil) }
+    let(:dump_target) { Exwiw::DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+    # belongs_to shops -> constrained.
+    let(:users) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'users', primary_key: 'id',
+        belongs_tos: [{ table_name: 'shops', foreign_key: 'shop_id' }],
+        columns: [{ name: 'id' }, { name: 'shop_id' }]
+      )
+    end
+    let(:shops) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'shops', primary_key: 'id', belongs_tos: [],
+        columns: [{ name: 'id' }, { name: 'name' }]
+      )
+    end
+    # No relation to shops -> would be a no-WHERE full dump.
+    let(:coupons) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'coupons', primary_key: 'id', belongs_tos: [],
+        columns: [{ name: 'id' }, { name: 'code' }]
+      )
+    end
+    let(:schema_migrations) do
+      Exwiw::TableConfig.from_symbol_keys(name: 'schema_migrations', type: 'rails_managed_schema_migrations')
+    end
+
+    let(:all_tables) { [shops, users, coupons, schema_migrations] }
+    let(:table_by_name) { all_tables.each_with_object({}) { |t, h| h[t.name] = t } }
+
+    def validate!
+      described_class.validate_target_scope!(all_tables, table_by_name, dump_target, logger)
+    end
+
+    it 'raises listing the unrelated table(s)' do
+      expect { validate! }.to raise_error(ArgumentError, /coupons/)
+    end
+
+    it 'flags only the unrelated table, not the target or its related tables' do
+      expect { validate! }.to raise_error(ArgumentError) { |e|
+        expect(e.message).to include('1 table(s)')
+        expect(e.message).to include('coupons')
+        expect(e.message).not_to include('users')
+      }
+    end
+
+    it 'does not flag rails-managed tables (treated as exempt)' do
+      expect { validate! }.to raise_error(ArgumentError) { |e|
+        expect(e.message).not_to include('schema_migrations')
+      }
+    end
+
+    it 'passes once the unrelated table is marked scope_exempt:true' do
+      coupons.scope_exempt = true
+      expect { validate! }.not_to raise_error
+    end
+
+    it 'passes once the unrelated table is marked ignore:true' do
+      coupons.ignore = true
+      expect { validate! }.not_to raise_error
+    end
+
+    it 'is a no-op in dump-all mode (no target table)' do
+      target = Exwiw::DumpTarget.new(table_name: nil, ids: [])
+      expect {
+        described_class.validate_target_scope!(all_tables, table_by_name, target, logger)
+      }.not_to raise_error
+    end
+
+    it 'is a no-op in scope-column mode' do
+      target = Exwiw::DumpTarget.new(ids: ['1'], scope_column: 'tenant_id')
+      expect {
+        described_class.validate_target_scope!(all_tables, table_by_name, target, logger)
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -327,6 +327,31 @@ module Exwiw
       end
     end
 
+    describe 'when a table has no relation to --target-table (would be a full dump)' do
+      let(:dump_target) { DumpTarget.new(table_name: 'shops', ids: ['1']) }
+
+      before do
+        FileUtils.cp('e2e/sqlite-schema/shops.json', File.join(schema_dir, 'shops.json'))
+        # system_announcements has no relation to shops; strip its scope_exempt so
+        # it falls into the "would be dumped in full" abort.
+        announcements = JSON.parse(File.read('e2e/sqlite-schema/system_announcements.json'))
+        announcements.delete('scope_exempt')
+        File.write(File.join(schema_dir, 'system_announcements.json'), JSON.dump(announcements))
+      end
+
+      it 'raises ArgumentError instead of dumping it in full' do
+        expect { runner.run }.to raise_error(ArgumentError, /system_announcements.*scope_exempt: true/m)
+      end
+
+      it 'passes once the table is marked scope_exempt:true' do
+        announcements = JSON.parse(File.read(File.join(schema_dir, 'system_announcements.json')))
+        announcements['scope_exempt'] = true
+        File.write(File.join(schema_dir, 'system_announcements.json'), JSON.dump(announcements))
+
+        expect { runner.run }.not_to raise_error
+      end
+    end
+
     describe 'with output_format copy' do
       let(:connection_config) do
         ConnectionConfig.new(


### PR DESCRIPTION
Closes #112.

## Why

In `--target-table` mode, a table with **no** relation to the target — no `belongs_to` path to it, and not referenced by any extractable child — compiles to a SELECT with no WHERE clause. exwiw would then dump that table **in full across every scope**.

For a table that was simply forgotten, that is a silent cross-scope data-exposure risk: it leaks every tenant's rows into a dump meant for one.

## What

exwiw now refuses to start and lists the offending table(s), mirroring the strict pre-flight already used by `--scope-column` mode. The same check runs under `exwiw explain`. To dump a genuine reference/master table in full, opt in explicitly with `scope_exempt: true`; to skip it, `ignore: true`. Rails-managed tables (`schema_migrations`, `ar_internal_metadata`) are exempt automatically.

SQL-only — `--scope-column` mode, the no-target dump-all mode, and MongoDB are unaffected.

⚠️ **BREAKING:** existing schemas that relied on the silent full dump must add `scope_exempt: true` to those tables.

## Notes

Split out of the WIP #119 (which also bundles #105 and #111); this PR is the #112 slice only, based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
