### PR TITLE
fix: --target-table に存在しないテーブルを指定したらエラーにする

### DIFF
--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -24,6 +24,7 @@ module Exwiw
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
       target = table_by_name[@dump_target.table_name]
+      validate_target_exists!(target)
       adapter.validate_as_dump_target!(target) if target
 
       dumpable_configs = configs.select { |c| adapter.dumpable?(c) }
@@ -60,6 +61,17 @@ module Exwiw
         json = JSON.parse(File.read(file))
         klass.from(json).reject_ignored_members!
       end
+    end
+
+    # Reject a `--target-table` (or `--target-collection`) absent from the loaded
+    # schema; mirrors Runner#validate_target_exists! so explain and export fail the
+    # same way on a typo. `target` is the looked-up config (nil when not found).
+    private def validate_target_exists!(target)
+      return if @dump_target.table_name.nil?
+      return unless target.nil?
+
+      raise ArgumentError,
+            "--target-table '#{@dump_target.table_name}' does not exist in the schema (#{@schema_dir})."
     end
 
     private def validate_ignored(configs)

--- a/lib/exwiw/explain_runner.rb
+++ b/lib/exwiw/explain_runner.rb
@@ -66,6 +66,10 @@ module Exwiw
     # Reject a `--target-table` (or `--target-collection`) absent from the loaded
     # schema; mirrors Runner#validate_target_exists! so explain and export fail the
     # same way on a typo. `target` is the looked-up config (nil when not found).
+    #
+    # TODO: same caveat as Runner#validate_target_exists! — this checks the schema
+    # (schema_dir JSON), not the live DB connection; verifying against the
+    # connection would need a table-exists capability on each adapter. revisit.
     private def validate_target_exists!(target)
       return if @dump_target.table_name.nil?
       return unless target.nil?

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -217,6 +217,11 @@ module Exwiw
     # matched nothing and produced an empty dump with no indication of the mistake.
     # `target` is the looked-up config (nil when not found); a nil dump target
     # (dump-all / scope-column mode) is allowed through.
+    #
+    # TODO: this checks the loaded schema (schema_dir JSON), not the live DB
+    # connection — a table that exists in the database but has no schema config
+    # is still rejected here. We may instead want to verify existence against the
+    # connection (would need a table-exists capability on each adapter). revisit.
     private def validate_target_exists!(target)
       return if @dump_target.table_name.nil?
       return unless target.nil?

--- a/lib/exwiw/runner.rb
+++ b/lib/exwiw/runner.rb
@@ -36,6 +36,7 @@ module Exwiw
       table_by_name = configs.each_with_object({}) { |config, hash| hash[config.name] = config }
 
       target = table_by_name[@dump_target.table_name]
+      validate_target_exists!(target)
       adapter.validate_as_dump_target!(target) if target
 
       dumpable_configs = configs.select { |c| adapter.dumpable?(c) }
@@ -209,6 +210,19 @@ module Exwiw
       end
 
       ignored_names.each { |n| @logger.info("Table '#{n}' is marked ignore:true (schema will be included, data extraction skipped)") }
+    end
+
+    # Reject a `--target-table` (or `--target-collection`) that does not match any
+    # table/collection in the loaded schema. Without this a typo'd target silently
+    # matched nothing and produced an empty dump with no indication of the mistake.
+    # `target` is the looked-up config (nil when not found); a nil dump target
+    # (dump-all / scope-column mode) is allowed through.
+    private def validate_target_exists!(target)
+      return if @dump_target.table_name.nil?
+      return unless target.nil?
+
+      raise ArgumentError,
+            "--target-table '#{@dump_target.table_name}' does not exist in the schema (#{@schema_dir})."
     end
 
     private def validate_rails_managed_target!(configs)

--- a/spec/explain_runner_spec.rb
+++ b/spec/explain_runner_spec.rb
@@ -98,5 +98,17 @@ module Exwiw
         expect { runner.run }.to raise_error(ArgumentError, /target-table 'shops' is marked ignore:true/)
       end
     end
+
+    describe '#run when --target-table does not exist in the schema' do
+      let(:dump_target) { DumpTarget.new(table_name: 'no_such_table', ids: ['1']) }
+
+      before do
+        FileUtils.cp('e2e/sqlite-schema/shops.json', File.join(schema_dir, 'shops.json'))
+      end
+
+      it 'raises ArgumentError' do
+        expect { runner.run }.to raise_error(ArgumentError, /--target-table 'no_such_table' does not exist in the schema/)
+      end
+    end
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -327,6 +327,18 @@ module Exwiw
       end
     end
 
+    describe 'when --target-table does not exist in the schema' do
+      let(:dump_target) { DumpTarget.new(table_name: 'no_such_table', ids: ['1']) }
+
+      before do
+        FileUtils.cp('e2e/sqlite-schema/shops.json', File.join(schema_dir, 'shops.json'))
+      end
+
+      it 'raises ArgumentError instead of silently dumping nothing' do
+        expect { runner.run }.to raise_error(ArgumentError, /--target-table 'no_such_table' does not exist in the schema/)
+      end
+    end
+
     describe 'with output_format copy' do
       let(:connection_config) do
         ConnectionConfig.new(


### PR DESCRIPTION
## 背景

`--target-table` にタイポなど存在しないテーブル名を渡しても、何にもマッチせず空のダンプが出力されるだけで、誤りに気づけなかった (#105)。

## 変更

`Runner` / `ExplainRunner` で、指定された target table がロード済みスキーマに無い場合は明確なエラーで停止するようにした。export / explain どちらも同じ挙動。

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)