### PR TITLE
feat: exwiw:schema:* タスクで config file の schema_dir を参照する

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,17 @@ The config generator is provided as a Rake task.
 bundle exec rake exwiw:schema:generate
 ```
 
-By default, the schema files will be saved in the `exwiw/schema` directory. You can specify a different output directory by setting the `EXWIW_SCHEMA_DIR_PATH` environment variable:
+The output directory is resolved in this order:
+
+1. the `EXWIW_SCHEMA_DIR_PATH` environment variable, if set;
+2. otherwise `schema_dir` from the config file (`exwiw.yml` / `exwiw.yaml` in the current directory), so the generator and the `exwiw` CLI share one location without repeating the path;
+3. otherwise the `exwiw/schema` default.
 
 ```sh
 EXWIW_SCHEMA_DIR_PATH=custom_directory bundle exec rake exwiw:schema:generate
 ```
+
+As with the CLI, a relative `schema_dir` in the config file is resolved relative to the config file's own directory.
 
 #### Tidying stale config (`schema:tidy`)
 

--- a/lib/exwiw.rb
+++ b/lib/exwiw.rb
@@ -6,6 +6,7 @@ require "json"
 require "serdes"
 
 require_relative "exwiw/ext_json"
+require_relative "exwiw/config_file"
 require_relative "exwiw/belongs_to"
 require_relative "exwiw/table_column"
 require_relative "exwiw/table_config"

--- a/lib/exwiw/config_file.rb
+++ b/lib/exwiw/config_file.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Exwiw
+  # Minimal reader for the exwiw config YAML (exwiw.yml / exwiw.yaml).
+  #
+  # The CLI has its own, richer config handling (CLI#apply_config_file!); this
+  # module exists for contexts that have no CLI in scope — chiefly the
+  # `exwiw:schema:*` rake tasks, which otherwise only knew the
+  # EXWIW_SCHEMA_DIR_PATH env var and a hard-coded default. It deliberately
+  # reads only what those tasks need (schema_dir) and never aborts the process:
+  # an absent or unreadable config simply yields nil so the caller can fall back.
+  module ConfigFile
+    # Mirrors CLI::DEFAULT_CONFIG_PATHS; .yml wins when both are present.
+    DEFAULT_PATHS = %w[exwiw.yml exwiw.yaml].freeze
+
+    module_function
+
+    # The `schema_dir` from the config file, expanded to an absolute path
+    # relative to the config file's own directory (matching the CLI). Returns
+    # nil when no config file is found, it cannot be parsed, or it does not set
+    # `schema_dir`. Pass an explicit `path` to read a specific file; otherwise
+    # the default paths are looked up in the current directory.
+    def schema_dir(path = nil)
+      path ||= DEFAULT_PATHS.map { |p| File.expand_path(p) }.find { |p| File.file?(p) }
+      return nil if path.nil? || !File.file?(path)
+
+      config =
+        begin
+          YAML.safe_load(File.read(path))
+        rescue Psych::SyntaxError
+          nil
+        end
+      return nil unless config.is_a?(Hash)
+
+      value = config["schema_dir"]
+      return nil if value.nil?
+
+      # Strip a trailing slash and resolve relative to the config file's
+      # directory, exactly as CLI#expand_dir does.
+      value = value.end_with?("/") ? value[0..-2] : value
+      File.expand_path(value, File.dirname(File.expand_path(path)))
+    end
+  end
+end

--- a/lib/tasks/exwiw.rake
+++ b/lib/tasks/exwiw.rake
@@ -2,12 +2,23 @@
 
 namespace :exwiw do
   namespace :schema do
+    # Output directory for the generated schema config. Precedence:
+    #   1. EXWIW_SCHEMA_DIR_PATH env var (explicit per-run override)
+    #   2. schema_dir in the exwiw config file (exwiw.yml/.yaml), so generating
+    #      the schema and running the `exwiw` CLI agree on one location without
+    #      repeating the path
+    #   3. the historical "exwiw/schema" default
+    # Resolved at task-run time (after `require "exwiw"` has loaded ConfigFile).
+    resolve_schema_dir = lambda do
+      ENV["EXWIW_SCHEMA_DIR_PATH"] || Exwiw::ConfigFile.schema_dir || "exwiw/schema"
+    end
+
     desc "Generate schema from application"
     task generate: :environment do
       require "exwiw"
 
       Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
+        output_dir: resolve_schema_dir.call,
       ).generate!
     end
 
@@ -16,7 +27,7 @@ namespace :exwiw do
       require "exwiw"
 
       result = Exwiw::SchemaGenerator.from_rails_application(
-        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
+        output_dir: resolve_schema_dir.call,
       ).tidy!
 
       if result.empty?
@@ -47,7 +58,7 @@ namespace :exwiw do
       require "exwiw"
 
       Exwiw::MongoidSchemaGenerator.from_rails_application(
-        output_dir: ENV["EXWIW_SCHEMA_DIR_PATH"] || "exwiw/schema",
+        output_dir: resolve_schema_dir.call,
         skip_unsupported: ENV["EXWIW_SKIP_UNSUPPORTED"] == "1",
       ).generate!
     end

--- a/spec/config_file_spec.rb
+++ b/spec/config_file_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+module Exwiw
+  RSpec.describe ConfigFile do
+    around do |example|
+      Dir.mktmpdir { |dir| @tmpdir = dir; example.run }
+    end
+
+    describe '.schema_dir' do
+      it 'reads schema_dir from an explicit config path, resolved relative to the file' do
+        path = File.join(@tmpdir, 'exwiw.yml')
+        File.write(path, "schema_dir: exwiw/schema\n")
+
+        expect(ConfigFile.schema_dir(path)).to eq(File.join(@tmpdir, 'exwiw/schema'))
+      end
+
+      it 'strips a trailing slash like the CLI does' do
+        path = File.join(@tmpdir, 'exwiw.yml')
+        File.write(path, "schema_dir: schema/\n")
+
+        expect(ConfigFile.schema_dir(path)).to eq(File.join(@tmpdir, 'schema'))
+      end
+
+      it 'leaves an absolute schema_dir untouched' do
+        abs = File.join(@tmpdir, 'abs-schema')
+        path = File.join(@tmpdir, 'exwiw.yml')
+        File.write(path, "schema_dir: #{abs}\n")
+
+        expect(ConfigFile.schema_dir(path)).to eq(abs)
+      end
+
+      it 'auto-discovers exwiw.yml in the current directory when no path is given' do
+        File.write(File.join(@tmpdir, 'exwiw.yml'), "schema_dir: from-yml\n")
+
+        Dir.chdir(@tmpdir) do
+          # realpath: macOS resolves the tmpdir symlink (/var -> /private/var)
+          # through the cwd that File.expand_path uses.
+          expect(ConfigFile.schema_dir).to eq(File.join(Dir.pwd, 'from-yml'))
+        end
+      end
+
+      it 'auto-discovers the exwiw.yaml extension too' do
+        File.write(File.join(@tmpdir, 'exwiw.yaml'), "schema_dir: from-yaml\n")
+
+        Dir.chdir(@tmpdir) do
+          expect(ConfigFile.schema_dir).to eq(File.join(Dir.pwd, 'from-yaml'))
+        end
+      end
+
+      it 'returns nil when no config file is present' do
+        Dir.chdir(@tmpdir) { expect(ConfigFile.schema_dir).to be_nil }
+      end
+
+      it 'returns nil when the config file does not set schema_dir' do
+        path = File.join(@tmpdir, 'exwiw.yml')
+        File.write(path, "output_format: insert\n")
+
+        expect(ConfigFile.schema_dir(path)).to be_nil
+      end
+
+      it 'returns nil for a non-existent explicit path' do
+        expect(ConfigFile.schema_dir(File.join(@tmpdir, 'nope.yml'))).to be_nil
+      end
+
+      it 'returns nil for a malformed YAML config instead of raising' do
+        path = File.join(@tmpdir, 'exwiw.yml')
+        File.write(path, "schema_dir: [unterminated\n")
+
+        expect(ConfigFile.schema_dir(path)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 背景

`exwiw:schema:generate` などのスキーマ生成タスクは `EXWIW_SCHEMA_DIR_PATH` 環境変数とハードコードされたデフォルトしか見ておらず、CLI 用に `exwiw.yml` の `schema_dir` を定義していても出力先を別途指定する必要があった (#111)。

## 変更

config file (`exwiw.yml` / `exwiw.yaml`) の `schema_dir` を出力先として参照するようにした。優先順位は 環境変数 > config file > 既定の `exwiw/schema` で、生成と CLI が同じ場所を共有できる。

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)