### PR TITLE
Preserve NULL in replace_with masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`replace_with` now preserves NULL.** A NULL source value stays NULL instead of being replaced by the masked literal (all adapters: MySQL, PostgreSQL, SQLite, MongoDB). Previously masking a nullable column clobbered NULL into a non-NULL value, losing the "not set" signal in the dump and making `.nil?`/`.present?`-dependent code behave differently than against production. The SQL adapters now wrap the masking expression in `CASE WHEN <column> IS NOT NULL THEN <masked> ELSE NULL END`, and the MongoDB adapter skips masking a field whose value is nil or absent. This is a behavior change for **nullable** masked columns only — `NOT NULL` columns are unaffected, and an empty string is a real value that is still masked (only true NULL/absent is preserved). It removes the need for hand-written `raw_sql` `CASE` workarounds to keep NULLs.
+
 ## [0.6.2] - 2026-06-21
 
 ## [0.6.1] - 2026-06-20

--- a/README.md
+++ b/README.md
@@ -614,6 +614,12 @@ and you can use the column name with `{}` to replace the value with the column v
 For example, Let assume we have the record which id is 1,
 then "user{id}@example.com" will be replaced with "user1@example.com".
 
+`replace_with` **preserves NULL**: a source value that is `NULL` (or, for MongoDB, an
+absent field) is left as-is instead of being replaced by the masked literal, so the
+"not set" signal survives into the dump. Only true `NULL`/absent is preserved — an empty
+string is a real value and is still masked. Because of this you do not need to hand-write a
+`raw_sql` `CASE WHEN ... IS NOT NULL ...` to keep NULLs.
+
 #### `raw_sql`
 
 It will used instead of the original value.

--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -202,6 +202,17 @@ module Exwiw
       rescue => e
         "<unavailable: #{e.class}: #{e.message}>"
       end
+
+      # Wrap a masking expression so a NULL source value stays NULL instead of
+      # being clobbered into a non-NULL literal. The guard checks the masked
+      # column itself (`column.name`) — not any other column the template may
+      # reference — so only true NULL is preserved; an empty string is a real
+      # value and is still masked. The column reference uses the same
+      # `<from_table>.<col>` form as the Plain branch. Shared by the SQL
+      # adapters' #compile_column_name ReplaceWith handling.
+      private def null_preserving(ast, column, masked_expr)
+        "CASE WHEN #{ast.from_table_name}.#{column.name} IS NOT NULL THEN #{masked_expr} ELSE NULL END"
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mongodb_adapter.rb
+++ b/lib/exwiw/adapter/mongodb_adapter.rb
@@ -514,6 +514,11 @@ module Exwiw
       # pair, with all per-config lookups hoisted into the plan.
       private def apply_mask_plan!(doc, plan)
         plan.masked_fields.each do |name, segments|
+          # Preserve a NULL / absent source value instead of clobbering it into a
+          # masked literal. `doc[name].nil?` is true for both an explicit nil and
+          # an absent key, so an absent key is left absent (not created).
+          next if doc[name].nil?
+
           doc[name] = render_template(segments, doc)
         end
         plan.embedded.each do |child|

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -330,7 +330,7 @@ module Exwiw
           end
 
           replaced = parts.join(", ")
-          "CONCAT(#{replaced})"
+          null_preserving(ast, column, "CONCAT(#{replaced})")
         else
           raise "Unreachable case: #{column.inspect}"
         end

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -456,7 +456,7 @@ module Exwiw
           end
 
           replaced = parts.join(", ")
-          "CONCAT(#{replaced})"
+          null_preserving(ast, column, "CONCAT(#{replaced})")
         else
           raise "Unreachable case: #{column.inspect}"
         end

--- a/lib/exwiw/adapter/sqlite_adapter.rb
+++ b/lib/exwiw/adapter/sqlite_adapter.rb
@@ -298,7 +298,7 @@ module Exwiw
           end
 
           replaced = parts.join(" || ")
-          "(#{replaced})"
+          null_preserving(ast, column, "(#{replaced})")
         else
           raise "Unreachable case: #{column.inspect}"
         end

--- a/spec/adapter/mongodb_adapter_spec.rb
+++ b/spec/adapter/mongodb_adapter_spec.rb
@@ -503,6 +503,51 @@ module Exwiw
           ])
           expect(parsed["posts"].first["title"]).to eq("masked-title-101")
         end
+
+        it "preserves a NULL field value instead of masking it" do
+          users_t = config_by_name.fetch("users")
+          adapter.build_query(users_t, dump_target, config_by_name)
+          rows = [
+            { "_id" => 1, "name" => nil, "email" => "user1@example.com", "shop_id" => 1 },
+          ]
+          parsed = JSON.parse(adapter.to_bulk_insert(rows, users_t))
+
+          expect(parsed["name"]).to be_nil
+          expect(parsed["email"]).to eq("masked1@example.com")
+        end
+
+        it "leaves an absent masked field absent (does not create the key)" do
+          users_t = config_by_name.fetch("users")
+          adapter.build_query(users_t, dump_target, config_by_name)
+          rows = [
+            { "_id" => 1, "email" => "user1@example.com", "shop_id" => 1 },
+          ]
+          parsed = JSON.parse(adapter.to_bulk_insert(rows, users_t))
+
+          expect(parsed).not_to have_key("name")
+          expect(parsed["email"]).to eq("masked1@example.com")
+        end
+
+        it "preserves a NULL field in an embedded subdocument" do
+          users_t = config_by_name.fetch("users")
+          adapter.build_query(users_t, dump_target, config_by_name)
+          rows = [
+            {
+              "_id" => 1,
+              "name" => "User 1",
+              "email" => "user1@example.com",
+              "shop_id" => 1,
+              "posts" => [
+                { "_id" => 101, "title" => nil },
+                { "_id" => 102, "title" => "Second" },
+              ],
+            },
+          ]
+          parsed = JSON.parse(adapter.to_bulk_insert(rows, users_t))
+
+          expect(parsed["posts"][0]["title"]).to be_nil
+          expect(parsed["posts"][1]["title"]).to eq("masked-title-102")
+        end
       end
 
       describe "#to_bulk_delete" do

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -156,7 +156,7 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CONCAT('masked', users.id, '@example.com'), users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1")
+            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CASE WHEN users.email IS NOT NULL THEN CONCAT('masked', users.id, '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1")
           end
         end
 
@@ -164,7 +164,15 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast("users.id > 1")) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CONCAT('masked', users.id, '@example.com'), users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1 AND users.id > 1")
+            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CASE WHEN users.email IS NOT NULL THEN CONCAT('masked', users.id, '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1 AND users.id > 1")
+          end
+        end
+
+        context "masking template referencing another column" do
+          let(:sql) { adapter.compile_ast(build_select_masked_reference_ast) }
+
+          it "guards on the masked column itself, not the referenced column" do
+            expect(sql).to eq("SELECT accounts.id, CASE WHEN accounts.nickname IS NOT NULL THEN CONCAT('user-', accounts.email) ELSE NULL END, accounts.email FROM accounts")
           end
         end
 

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -73,7 +73,7 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CONCAT('masked', users.id, '@example.com'), users.shop_id, users.updated_at, users.created_at, users.role FROM users WHERE users.shop_id = 1")
+            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CASE WHEN users.email IS NOT NULL THEN CONCAT('masked', users.id, '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at, users.role FROM users WHERE users.shop_id = 1")
           end
         end
 
@@ -81,7 +81,15 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast("users.id > 1")) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CONCAT('masked', users.id, '@example.com'), users.shop_id, users.updated_at, users.created_at, users.role FROM users WHERE users.shop_id = 1 AND users.id > 1")
+            expect(sql).to eq("SELECT users.id, CONCAT('masked', users.id), CASE WHEN users.email IS NOT NULL THEN CONCAT('masked', users.id, '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at, users.role FROM users WHERE users.shop_id = 1 AND users.id > 1")
+          end
+        end
+
+        context "masking template referencing another column" do
+          let(:sql) { adapter.compile_ast(build_select_masked_reference_ast) }
+
+          it "guards on the masked column itself, not the referenced column" do
+            expect(sql).to eq("SELECT accounts.id, CASE WHEN accounts.nickname IS NOT NULL THEN CONCAT('user-', accounts.email) ELSE NULL END, accounts.email FROM accounts")
           end
         end
 

--- a/spec/adapter/sqlite_adapter_spec.rb
+++ b/spec/adapter/sqlite_adapter_spec.rb
@@ -68,7 +68,7 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, ('masked' || users.id), ('masked' || users.id || '@example.com'), users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1")
+            expect(sql).to eq("SELECT users.id, ('masked' || users.id), CASE WHEN users.email IS NOT NULL THEN ('masked' || users.id || '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1")
           end
         end
 
@@ -76,7 +76,15 @@ module Exwiw
           let(:sql) { adapter.compile_ast(build_select_users_ast("users.id > 1")) }
 
           it "builds sql" do
-            expect(sql).to eq("SELECT users.id, ('masked' || users.id), ('masked' || users.id || '@example.com'), users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1 AND users.id > 1")
+            expect(sql).to eq("SELECT users.id, ('masked' || users.id), CASE WHEN users.email IS NOT NULL THEN ('masked' || users.id || '@example.com') ELSE NULL END, users.shop_id, users.updated_at, users.created_at FROM users WHERE users.shop_id = 1 AND users.id > 1")
+          end
+        end
+
+        context "masking template referencing another column" do
+          let(:sql) { adapter.compile_ast(build_select_masked_reference_ast) }
+
+          it "guards on the masked column itself, not the referenced column" do
+            expect(sql).to eq("SELECT accounts.id, CASE WHEN accounts.nickname IS NOT NULL THEN ('user-' || accounts.email) ELSE NULL END, accounts.email FROM accounts")
           end
         end
 
@@ -248,6 +256,52 @@ module Exwiw
               [5, 1, 5, 2, "2025-01-01 00:00:00", "2025-01-01 00:00:00"],
             ])
           end
+        end
+      end
+
+      # End-to-end (against a real, isolated sqlite file) proof that masking
+      # preserves a NULL source value: a NULL row stays NULL, a non-NULL row is
+      # masked. Self-contained so it does not depend on the shared seeded DB
+      # (whose masked columns are all NOT NULL).
+      describe "NULL-preserving masking" do
+        let(:db_path) { Tempfile.new(["null_mask", ".sqlite3"]).path }
+        let(:null_connection_config) do
+          ConnectionConfig.new(
+            adapter: adapter_name,
+            database_name: db_path,
+            host: nil,
+            port: nil,
+            user: nil,
+            password: nil,
+          )
+        end
+        let(:null_adapter) { described_class.new(null_connection_config, logger) }
+        let(:masked_ast) do
+          table = Exwiw::TableConfig.from_symbol_keys(
+            name: "accounts",
+            primary_key: "id",
+            belongs_tos: [],
+            columns: [{ name: "id" }, { name: "nickname", replace_with: "masked-{id}" }],
+          )
+          QueryAst::Select.new.tap do |ast|
+            ast.from(table.name)
+            ast.select(table.columns)
+          end
+        end
+
+        before do
+          db = ::SQLite3::Database.new(db_path)
+          db.execute("CREATE TABLE accounts (id INTEGER PRIMARY KEY, nickname TEXT)")
+          db.execute("INSERT INTO accounts (id, nickname) VALUES (1, NULL)")
+          db.execute("INSERT INTO accounts (id, nickname) VALUES (2, 'Alice')")
+          db.close
+        end
+
+        it "keeps a NULL source value NULL and masks a non-NULL value" do
+          expect(null_adapter.execute(masked_ast).to_a).to eq([
+            [1, nil],
+            [2, "masked-2"],
+          ])
         end
       end
 

--- a/spec/support/ast_factory.rb
+++ b/spec/support/ast_factory.rb
@@ -38,6 +38,28 @@ module AstFactory
     end
   end
 
+  # A select whose masked column (`nickname`) carries a `replace_with` template
+  # that references a DIFFERENT column (`{email}`). Used to assert the
+  # NULL-preserving guard keys off the masked column itself, not the referenced
+  # one. Adapter-agnostic (the config is built inline, not loaded per adapter).
+  def build_select_masked_reference_ast
+    table = Exwiw::TableConfig.from_symbol_keys(
+      name: "accounts",
+      primary_key: "id",
+      belongs_tos: [],
+      columns: [
+        { name: "id" },
+        { name: "nickname", replace_with: "user-{email}" },
+        { name: "email" },
+      ],
+    )
+
+    QueryAst::Select.new.tap do |ast|
+      ast.from(table.name)
+      ast.select(table.columns)
+    end
+  end
+
   def build_join_query_ast
     order_items_table = order_items_table(adapter_name)
 


### PR DESCRIPTION
## 概要

`replace_with` マスキングで、元の値が NULL でも非 NULL リテラルで上書きしていた問題を修正。マスク後も NULL（MongoDB は欠損フィールド）を保持する。

## 背景

NULL→リテラル上書きにより dump から「未入力(NULL)」シグナルが失われ、`.nil?` / `.present?` 依存コードが本番と異なる挙動になっていた。従来は consumer 側で列ごとに `raw_sql` の `CASE` を書く必要があった。

## 変更

- SQL (MySQL / PostgreSQL / SQLite): マスク式を `CASE WHEN <column> IS NOT NULL THEN <masked> ELSE NULL END` でラップ（共通ヘルパー `Adapter::Base#null_preserving`）
- MongoDB: `apply_mask_plan!` で nil / 欠損フィールドはマスクをスキップ
- 判定はマスク対象列自身を見る。`raw_sql` は対象外（従来どおり）
- NOT NULL 列は影響なし。空文字 `''` は実値として従来どおりマスク（NULL のみ保持）。**破壊的挙動変更**

## テスト

`bundle exec rspec` 520 examples / 0 failures。SQL 3 アダプタの compile_ast アサーション更新、sqlite 実 DB の NULL 保持結合テスト、MongoDB の nil / 欠損保持テストを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)