### PR TITLE
fix: 非 ActiveRecord を指す belongs_to をスキーマ生成から除外

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`schema:generate` skips a `belongs_to` whose target is not an ActiveRecord model instead of crashing.** A `belongs_to` can point at a non-ActiveRecord class — most commonly an ActiveHash/ActiveYaml master (`belongs_to :equipment, class_name: "SomeActiveYamlModel"`). active_hash registers these as ordinary `belongs_to` reflections, but the target class has no database table, so resolving its `table_name` raised and aborted generation. Such a relation is not a DB edge exwiw can join or extract across, so it is now dropped from the generated belongs_tos; the underlying foreign-key column is still emitted as a plain column. A bare `belongs_to` to a plain non-AR class — which makes ActiveRecord raise while resolving the target — is treated the same way. Polymorphic associations are unaffected.
+
 ## [0.8.0] - 2026-06-24
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,8 @@ gem "mongoid"
 
 gem "activerecord"
 
+# Exercises the non-ActiveRecord belongs_to target path (a master with no DB
+# table) in schema_generator_non_active_record_belongs_to_spec.
+gem "active_hash", group: :test
+
 gem "trilogy", group: :test

--- a/lib/exwiw/schema_generator.rb
+++ b/lib/exwiw/schema_generator.rb
@@ -291,7 +291,9 @@ module Exwiw
     end
 
     private def aggregate_belongs_tos(models)
-      belongs_to_assocs = models.flat_map { |m| belongs_to_associations_for(m) }
+      belongs_to_assocs = models
+        .flat_map { |m| belongs_to_associations_for(m) }
+        .select { |assoc| assoc.polymorphic? || active_record_target?(assoc) }
       owner_db = database_name_for(models.first)
 
       non_polymorphic = belongs_to_assocs
@@ -374,6 +376,31 @@ module Exwiw
 
       left = model.left_reflection
       assocs.reject { |assoc| assoc.equal?(left) }
+    end
+
+    # Whether a (non-polymorphic) belongs_to points at an ActiveRecord model.
+    #
+    # A belongs_to can target a non-ActiveRecord class — most commonly an
+    # ActiveHash/ActiveYaml master (`belongs_to :equipment, class_name:
+    # "SomeActiveYamlModel"`). active_hash registers these as ordinary
+    # `belongs_to` reflections, yet the target class has no database table, so
+    # `assoc.table_name` (which delegates to `klass.table_name`) raises. Such a
+    # relation is not a DB edge exwiw can join or extract across, so it is
+    # dropped from the generated belongs_tos; the underlying foreign-key column
+    # is still emitted as a plain column. Polymorphic associations cannot be
+    # `klass`-resolved, so callers must screen those out before calling this.
+    #
+    # Resolving the target class behaves differently per non-AR shape: an
+    # ActiveHash reflection returns the class fine (the crash is later, at
+    # `table_name`), while a bare `belongs_to` to a plain class makes AR raise
+    # ArgumentError ("... is not an ActiveRecord::Base subclass") right here when
+    # the klass is computed. Both mean "not a DB relation", so rescue the lookup
+    # and treat either as a non-AR target to skip.
+    private def active_record_target?(assoc)
+      klass = assoc.klass
+      klass.is_a?(Class) && klass < ActiveRecord::Base ? true : false
+    rescue StandardError
+      false
     end
 
     # Enumerate the concrete models that can be targets of the polymorphic

--- a/spec/schema_generator_non_active_record_belongs_to_spec.rb
+++ b/spec/schema_generator_non_active_record_belongs_to_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "active_record"
+require "sqlite3"
+require "active_hash"
+
+# Regression test for a `belongs_to` whose target is NOT an ActiveRecord model.
+#
+# A model may `belongs_to` an ActiveHash/ActiveYaml master, e.g.
+# `belongs_to :equipment, class_name: "SomeActiveYamlModel"`. With
+# `ActiveHash::Associations::ActiveRecordExtensions`, active_hash registers this
+# as an ordinary `belongs_to` reflection whose `klass` resolves to the
+# ActiveHash class — which has NO database table, so `reflection.table_name`
+# (-> `klass.table_name`) raises NoMethodError. `SchemaGenerator` used to call
+# `assoc.table_name` on every non-polymorphic belongs_to and would abort the
+# whole `schema:generate`. The generator must instead skip the non-AR relation
+# (its foreign-key column is still emitted as a plain column).
+#
+# `OmakaseStartEquipment` (ActiveYaml) in the bongo app is the real-world
+# trigger.
+module Exwiw
+  module SchemaGeneratorNonArFixtures
+    # ActiveHash master with no database table — the reflection target that used
+    # to crash schema generation.
+    class Equipment < ActiveHash::Base
+      self.data = [{ id: 1, code: "A" }]
+    end
+
+    class OrderItem < ::ActiveRecord::Base
+      extend ActiveHash::Associations::ActiveRecordExtensions
+
+      self.table_name = "order_items"
+
+      belongs_to :order, class_name: "Exwiw::SchemaGeneratorNonArFixtures::Order"
+      # The offending relation: target is an ActiveHash model, not ActiveRecord.
+      belongs_to :equipment, class_name: "Exwiw::SchemaGeneratorNonArFixtures::Equipment"
+    end
+
+    class Order < ::ActiveRecord::Base
+      self.table_name = "orders"
+    end
+  end
+
+  RSpec.describe SchemaGenerator do
+    describe "belongs_to whose target is not an ActiveRecord model" do
+      before(:all) do
+        ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        conn = ActiveRecord::Base.connection
+        conn.create_table(:orders) { |t| t.string :name }
+        conn.create_table(:order_items) do |t|
+          t.integer :order_id
+          t.integer :equipment_id
+          t.integer :quantity
+        end
+      end
+
+      after(:all) do
+        ActiveRecord::Base.remove_connection
+      end
+
+      around do |ex|
+        Dir.mktmpdir do |dir|
+          @output_dir = dir
+          ex.run
+        end
+      end
+
+      let(:models) do
+        [SchemaGeneratorNonArFixtures::OrderItem, SchemaGeneratorNonArFixtures::Order]
+      end
+      let(:tables) { described_class.new(models: models, output_dir: @output_dir).build_tables }
+      let(:order_items) { tables.find { |t| t.name == "order_items" } }
+
+      it "registers the ActiveHash belongs_to as a reflection (the crash entry point)" do
+        equipment = SchemaGeneratorNonArFixtures::OrderItem
+          .reflect_on_all_associations(:belongs_to)
+          .find { |a| a.name == :equipment }
+        expect(equipment).not_to be_nil
+        expect(equipment.klass).to eq(SchemaGeneratorNonArFixtures::Equipment)
+        expect(equipment.klass).not_to be < ActiveRecord::Base
+      end
+
+      it "does not raise on the non-ActiveRecord belongs_to" do
+        expect { tables }.not_to raise_error
+      end
+
+      it "drops the non-AR relation but keeps the AR one" do
+        targets = order_items.belongs_tos.map(&:table_name)
+        expect(targets).to include("orders")
+        expect(targets).not_to include("equipment")
+      end
+
+      it "still emits the foreign-key column of the dropped relation as a plain column" do
+        expect(order_items.column_names).to include("equipment_id")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## なぜやるのか

`belongs_to` の中には DB テーブルを持たないクラス（active_hash / active_yaml の master 等）を `class_name` で指すものがある。exwiw はこれを DB 上の関連として join/extract できないが、現状は `table_name` 解決時に例外になりスキーマ生成が止まってしまう。

## 変更

- 非 ActiveRecord を指す（polymorphic でない）`belongs_to` を belongs_tos 生成から除外。FK カラム自体は通常カラムとして残る
- 上記を検証する spec と、テスト用の `active_hash`（test グループ）を追加
