### PR TITLE
fix: make forward scope cascade multi-hop (cycle-bounded)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Forward scope (`via_scoped_parent`) now cascades across multiple `belongs_to` hops instead of dying after one.** A table with no scope column of its own is scoped by constraining it to its `belongs_to` parent's in-scope ids (`fk IN (SELECT parent.pk FROM <parent's scoped query>)`). Previously the parent was rebuilt with forward scoping turned off, so if the parent was *itself* scoped only through *its* parent (e.g. an identity-family table two or more hops below a `reverse_scope`/`referenced_by` table — `users ← end_users ← end_user_profiles`), the rebuilt parent came back unconstrained and the child was classified `:unscopable` — forcing a `scope_exempt` full dump and re-introducing the bloat the prune removes. The boolean single-hop bound is replaced by a forward-path guard: the rescue keeps forward scoping enabled while rebuilding the parent (appending the current table to the path), so the cascade recurses N levels and produces a correspondingly nested `IN (subquery)`; it terminates only on a genuine `belongs_to` cycle (a table already on the path is not revisited, falling through to `:unscopable`). The single-unambiguous-parent rule and the polymorphic-skip are unchanged, and the reverse arms still cannot loop back through the table being reverse-scoped. SQL adapters only.
+
 ## [0.8.2] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ Each table is resolved as follows:
   (`fk IN (SELECT parent.pk FROM <parent's scoped query>)`). This covers a *hub*
   table that has no scope column and is scoped only because an extractable child
   references it (see referenced-by below): the hub's other `belongs_to` children
-  ride along to just the in-scope rows instead of being dumped in full. Limited to
-  a single forward hop and a single unambiguous scopable parent.
+  ride along to just the in-scope rows instead of being dumped in full. The parent
+  itself may be scoped the same way, so this **cascades across multiple hops**
+  (each a single unambiguous scopable parent) and the subquery nests
+  correspondingly; the recursion terminates on a genuine `belongs_to` cycle (a
+  table already on the path is left `:unscopable` rather than looped on).
 - **Cannot be scoped at all** (no scope column and no path to one) → exwiw
   **aborts** and lists the offending tables, so an unscoped table is never silently
   dumped in full. For each, either declare a `scope_column`, add a `belongs_to`
@@ -619,7 +622,7 @@ Notes:
 - **`column` is explicit**, so a *non-default* foreign key (e.g. `kantan_yoyaku_user_id`, or `organization_admins.id` which itself references `users.id`) is honored, and even a column with no declared `belongs_to` edge can be enumerated.
 - **Only scoped referencers belong in `via`.** Each arm's query must come out constrained; an unconstrained referencer (e.g. a `scope_exempt` table, or one with no path to a scope) would project *every* id and union the whole table back — so such an arm is **skipped with a warning** rather than silently widening the dump. An unknown table is likewise skipped with a warning. If no arm survives, the table stays unscopable and (in [scope-column mode](#scope-column-mode)) the run aborts via `validate_scope!`.
 - **NULLs are excluded** per arm (`IS NOT NULL`).
-- **Satellites need no config.** A table that `belongs_to` the reverse-scoped table (e.g. `end_users.id → users.id`, or `identities.user_id → users.id`) tightens to the kept ids automatically through the normal cascade — only the reverse-scoped table itself declares `reverse_scope`.
+- **Satellites need no config.** A table that `belongs_to` the reverse-scoped table (e.g. `end_users.id → users.id`, or `identities.user_id → users.id`) tightens to the kept ids automatically through the normal cascade — only the reverse-scoped table itself declares `reverse_scope`. The cascade is **multi-hop**, so a table several `belongs_to` hops below the reverse-scoped table (e.g. `end_user_profiles → end_users → users`) also tightens automatically, with no config of its own.
 - Works in both single-target and scope-column mode. Polymorphic foreign keys are not eligible as anchors (the named `column` is always a concrete column).
 
 ### Rails-managed tables (special `type` values)

--- a/lib/exwiw/query_ast_builder.rb
+++ b/lib/exwiw/query_ast_builder.rb
@@ -2,8 +2,8 @@
 
 module Exwiw
   class QueryAstBuilder
-    def self.run(table_name, table_by_name, dump_target, logger, allow_reverse: true, allow_forward: true)
-      new(table_name, table_by_name, dump_target, logger, allow_reverse: allow_reverse, allow_forward: allow_forward).run
+    def self.run(table_name, table_by_name, dump_target, logger, allow_reverse: true, forward_path: [])
+      new(table_name, table_by_name, dump_target, logger, allow_reverse: allow_reverse, forward_path: forward_path).run
     end
 
     # Scope-column mode classification for a single table. One of
@@ -49,17 +49,20 @@ module Exwiw
 
     attr_reader :table_name, :table_by_name, :dump_target
 
-    def initialize(table_name, table_by_name, dump_target, logger, allow_reverse: true, allow_forward: true)
+    def initialize(table_name, table_by_name, dump_target, logger, allow_reverse: true, forward_path: [])
       @table_name = table_name
       @table_by_name = table_by_name
       @dump_target = dump_target
       @logger = logger
       @allow_reverse = allow_reverse
-      # @allow_forward gates the "scope via an indirectly-scoped belongs_to
-      # parent" rescue (build_belongs_to_scoped_clause). Disabled while building a
-      # parent/child subquery so a single forward hop never recurses into another
-      # (which could loop on a belongs_to cycle).
-      @allow_forward = allow_forward
+      # @forward_path is the chain of tables currently being forward-resolved by
+      # the "scope via an indirectly-scoped belongs_to parent" rescue
+      # (build_belongs_to_scoped_clause). Each forward hop appends the table it is
+      # descending from, so the rescue recurses N levels (users -> end_users ->
+      # end_user_profiles -> ...) and stops only on a real belongs_to cycle: a
+      # table already on the path is not re-resolved, falling through to
+      # :unscopable instead of looping forever.
+      @forward_path = forward_path
     end
 
     def run
@@ -187,10 +190,11 @@ module Exwiw
         next if relation.nil? || relation.polymorphic?
 
         # Build the child's own extraction query. allow_reverse:false stops a
-        # chain of FK-less tables from recursing back into each other;
-        # allow_forward:false stops the child from forward-scoping back through
-        # this very table (which would loop).
-        child_query = self.class.run(other.name, table_by_name, dump_target, @logger, allow_reverse: false, allow_forward: false)
+        # chain of FK-less tables from recursing back into each other; adding this
+        # table to forward_path stops the child from forward-scoping back through
+        # it (which would loop) while still letting the child forward-scope
+        # through other tables.
+        child_query = self.class.run(other.name, table_by_name, dump_target, @logger, allow_reverse: false, forward_path: @forward_path + [table.name])
 
         # Only an *already constrained* child narrows anything; an unconstrained
         # child would select every fk value (i.e. dump all) and not help.
@@ -248,12 +252,12 @@ module Exwiw
           next
         end
 
-        # Build the referencer's own scoped extraction query. allow_reverse /
-        # allow_forward are disabled to bound recursion exactly as the
-        # single-referencer path does (a referencer scopable only via its own
-        # reverse/forward rescue would loop or, worse, recurse back into this
-        # table).
-        ref_query = self.class.run(referencer.name, table_by_name, dump_target, @logger, allow_reverse: false, allow_forward: false)
+        # Build the referencer's own scoped extraction query. allow_reverse is
+        # disabled and this table is added to forward_path to bound recursion
+        # exactly as the single-referencer path does (a referencer that could only
+        # be scoped by recursing back into this table would loop); the referencer
+        # may still forward-scope through other tables.
+        ref_query = self.class.run(referencer.name, table_by_name, dump_target, @logger, allow_reverse: false, forward_path: @forward_path + [table.name])
 
         unless ref_query.where_clauses.any? || ref_query.join_clauses.any?
           @logger.warn(
@@ -297,6 +301,13 @@ module Exwiw
     # them out of a full dump. Returns nil when there is no single, unambiguous
     # scopable parent, leaving the caller on the unscopable path.
     private def build_belongs_to_scoped_clause(table)
+      # This table plus every ancestor currently being forward-resolved. A
+      # candidate parent already on this path would close a belongs_to cycle, so
+      # it is skipped; threading the grown path into the parent build lets the
+      # cascade recurse N hops (users -> end_users -> end_user_profiles -> ...)
+      # and terminate only when a table reappears.
+      forward_path = @forward_path + [table.name]
+
       candidates = table.belongs_tos.filter_map do |relation|
         # A polymorphic belongs_to points at several parent tables through one
         # column, so it cannot project to a single parent id set; skip it.
@@ -305,10 +316,15 @@ module Exwiw
         parent = table_by_name[relation.table_name]
         next if parent.nil?
 
+        # Cycle guard: descending into a parent already on the forward path would
+        # loop (a -> b -> a). Stop, leaving this table on the :unscopable path.
+        next if forward_path.include?(parent.name)
+
         # Build the parent's own scoped query. allow_reverse stays true so the
-        # parent may be scoped via referenced_by; allow_forward:false bounds this
-        # to a single forward hop so a belongs_to cycle cannot loop.
-        parent_query = self.class.run(parent.name, table_by_name, dump_target, @logger, allow_reverse: true, allow_forward: false)
+        # parent may be scoped via referenced_by, and forward scoping stays
+        # enabled so a parent that is itself scoped via *its* parent resolves
+        # too — this is what makes the cascade multi-hop.
+        parent_query = self.class.run(parent.name, table_by_name, dump_target, @logger, allow_reverse: true, forward_path: forward_path)
 
         # Only a constrained parent narrows anything; an unconstrained parent
         # would select every pk (i.e. dump all) and not help.
@@ -460,9 +476,16 @@ module Exwiw
       return :direct if directly_scoped?(table)
       return :via_path if build_join_clauses_scoped(table).any?
       return :referenced_by if @allow_reverse && build_referenced_by_clause(table)
-      return :via_scoped_parent if @allow_forward && build_belongs_to_scoped_clause(table)
+      return :via_scoped_parent if forward_scope_allowed?(table) && build_belongs_to_scoped_clause(table)
 
       :unscopable
+    end
+
+    # True when this table may still attempt the forward "scope via a scoped
+    # belongs_to parent" rescue: it is not already on the forward-resolution
+    # path, so descending into its parent cannot revisit it (a belongs_to cycle).
+    private def forward_scope_allowed?(table)
+      !@forward_path.include?(table.name)
     end
 
     private def build_scoped(table)
@@ -502,11 +525,13 @@ module Exwiw
         end
       end
 
-      if @allow_forward
+      if forward_scope_allowed?(table)
         # Belongs_to a parent that is itself scoped but carries no scope column of
         # its own (so via_path cannot terminate on it) — e.g. a hub table scoped
-        # only via referenced_by. Constrain this table to that parent's in-scope
-        # ids so its rows ride along instead of being dumped in full.
+        # only via referenced_by, or a parent that is itself scoped through *its*
+        # parent. Constrain this table to that parent's in-scope ids so its rows
+        # ride along instead of being dumped in full; the parent build recurses
+        # the cascade further up.
         parent_clause = build_belongs_to_scoped_clause(table)
         if parent_clause
           ast.where(parent_clause)
@@ -514,12 +539,13 @@ module Exwiw
         end
       end
 
-      # Only the genuine top-level build (no rescue disabled) is allowed to fail
-      # hard. The Runner/ExplainRunner pre-flight (validate_scope!) rejects
-      # unscopable tables before extraction, so a top-level build never
-      # legitimately lands here; if it does, raise rather than emit an unfiltered
-      # (potential full PII) dump.
-      if @allow_reverse && @allow_forward
+      # Only the genuine top-level build (allow_reverse on, forward_path empty —
+      # i.e. no rescue subquery in progress) is allowed to fail hard. The
+      # Runner/ExplainRunner pre-flight (validate_scope!) rejects unscopable
+      # tables before extraction, so a top-level build never legitimately lands
+      # here; if it does, raise rather than emit an unfiltered (potential full
+      # PII) dump.
+      if @allow_reverse && @forward_path.empty?
         raise ArgumentError, scope_unscopable_message(table)
       end
 

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -238,6 +238,19 @@ module Exwiw
             )
           end
         end
+
+        context "select query with a three-level nested IN subquery (multi-hop forward cascade)" do
+          let(:sql) { adapter.compile_ast(build_multi_hop_nested_in_ast) }
+
+          it "renders the subqueries recursively at every level" do
+            expect(sql).to eq(
+              "SELECT * FROM projects WHERE projects.team_id IN (" \
+              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
+              "SELECT companies.id FROM companies WHERE companies.id IN (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+            )
+          end
+        end
       end
 
       describe "#execute" do

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -462,6 +462,19 @@ module Exwiw
           end
         end
 
+        context "compile_ast with a three-level nested IN subquery (multi-hop forward cascade)" do
+          it "renders the subqueries recursively at every level (matching types, no cast)" do
+            sql = adapter.compile_ast(build_multi_hop_nested_in_ast)
+            expect(sql).to eq(
+              "SELECT * FROM projects WHERE projects.team_id IN (" \
+              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
+              "SELECT companies.id FROM companies WHERE companies.id IN (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+            )
+            expect(sql).not_to include("::text")
+          end
+        end
+
         context "column_pg_type returns nil (graceful fallback)" do
           it "does not cast and does not raise" do
             allow(adapter).to receive(:column_pg_type).and_return(nil)

--- a/spec/adapter/sqlite_adapter_spec.rb
+++ b/spec/adapter/sqlite_adapter_spec.rb
@@ -160,6 +160,19 @@ module Exwiw
             )
           end
         end
+
+        context "select query with a three-level nested IN subquery (multi-hop forward cascade)" do
+          let(:sql) { adapter.compile_ast(build_multi_hop_nested_in_ast) }
+
+          it "renders the subqueries recursively at every level" do
+            expect(sql).to eq(
+              "SELECT * FROM projects WHERE projects.team_id IN (" \
+              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
+              "SELECT companies.id FROM companies WHERE companies.id IN (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+            )
+          end
+        end
       end
 
       describe "#commented_sql" do

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -1129,4 +1129,186 @@ RSpec.describe Exwiw::QueryAstBuilder do
       )
     end
   end
+
+  describe 'multi-hop forward scope cascade (via_scoped_parent)' do
+    # `companies` carries no scope column and has no belongs_to of its own; it is
+    # scoped via reverse_scope (the scoped `memberships` point at it). Three
+    # tables then hang off it through a chain of belongs_to hops:
+    #
+    #   companies (reverse_scope) <- teams <- projects <- tasks
+    #
+    # Each link is scoped by constraining it to its parent's in-scope ids, and
+    # the parent is itself scoped the same way — so the rescue must recurse the
+    # whole chain rather than dying after a single forward hop.
+    let(:logger) { Logger.new(nil) }
+    let(:dump_target) { Exwiw::DumpTarget.new(ids: ['t1'], scope_column: 'tenant_id') }
+
+    let(:companies) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'companies', primary_key: 'id', belongs_tos: [],
+        reverse_scope: { via: [{ table: 'memberships', column: 'company_id' }] },
+        columns: [{ name: 'id' }, { name: 'name' }]
+      )
+    end
+    let(:memberships) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'memberships', primary_key: 'id',
+        belongs_tos: [{ table_name: 'companies', foreign_key: 'company_id' }],
+        columns: [{ name: 'id' }, { name: 'company_id' }, { name: 'tenant_id' }]
+      )
+    end
+    let(:teams) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'teams', primary_key: 'id',
+        belongs_tos: [{ table_name: 'companies', foreign_key: 'company_id' }],
+        columns: [{ name: 'id' }, { name: 'company_id' }, { name: 'label' }]
+      )
+    end
+    let(:projects) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'projects', primary_key: 'id',
+        belongs_tos: [{ table_name: 'teams', foreign_key: 'team_id' }],
+        columns: [{ name: 'id' }, { name: 'team_id' }, { name: 'name' }]
+      )
+    end
+    let(:tasks) do
+      Exwiw::TableConfig.from_symbol_keys(
+        name: 'tasks', primary_key: 'id',
+        belongs_tos: [{ table_name: 'projects', foreign_key: 'project_id' }],
+        columns: [{ name: 'id' }, { name: 'project_id' }, { name: 'title' }]
+      )
+    end
+    let(:schema_migrations) do
+      Exwiw::TableConfig.from_symbol_keys(name: 'schema_migrations', type: 'rails_managed_schema_migrations')
+    end
+
+    let(:all_tables) { [companies, memberships, teams, projects, tasks, schema_migrations] }
+    let(:table_by_name) { all_tables.each_with_object({}) { |t, h| h[t.name] = t } }
+
+    def build(name)
+      described_class.run(name, table_by_name, dump_target, logger)
+    end
+
+    it 'classifies every hop below the reverse-scoped table as :via_scoped_parent' do
+      expect(described_class.scope_category('companies', table_by_name, dump_target, logger)).to eq(:referenced_by)
+      expect(described_class.scope_category('teams', table_by_name, dump_target, logger)).to eq(:via_scoped_parent)
+      expect(described_class.scope_category('projects', table_by_name, dump_target, logger)).to eq(:via_scoped_parent)
+      expect(described_class.scope_category('tasks', table_by_name, dump_target, logger)).to eq(:via_scoped_parent)
+    end
+
+    it 'no longer leaves the deep hops unscopable, so validate_scope! passes' do
+      expect {
+        described_class.validate_scope!(all_tables, table_by_name, dump_target, logger)
+      }.not_to raise_error
+    end
+
+    it 'nests the second hop one level below the reverse_scope UNION (sqlite)' do
+      expect(sqlite_adapter.compile_ast(build('projects'))).to eq(
+        'SELECT projects.id, projects.team_id, projects.name FROM projects ' \
+        'WHERE projects.team_id IN (' \
+        'SELECT teams.id FROM teams WHERE teams.company_id IN (' \
+        'SELECT companies.id FROM companies WHERE companies.id IN (' \
+        "SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' " \
+        'AND memberships.company_id IS NOT NULL)))'
+      )
+    end
+
+    it 'nests every hop for the deepest table (sqlite)' do
+      expect(sqlite_adapter.compile_ast(build('tasks'))).to eq(
+        'SELECT tasks.id, tasks.project_id, tasks.title FROM tasks ' \
+        'WHERE tasks.project_id IN (' \
+        'SELECT projects.id FROM projects WHERE projects.team_id IN (' \
+        'SELECT teams.id FROM teams WHERE teams.company_id IN (' \
+        'SELECT companies.id FROM companies WHERE companies.id IN (' \
+        "SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' " \
+        'AND memberships.company_id IS NOT NULL))))'
+      )
+    end
+
+    context 'a belongs_to cycle (a -> b -> a) with no other scope' do
+      # Neither table carries a scope column, reverse_scope, or a path to one;
+      # they only point at each other. The cascade must terminate on the cycle
+      # rather than recursing forever.
+      let(:node_x) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'node_x', primary_key: 'id',
+          belongs_tos: [{ table_name: 'node_y', foreign_key: 'y_id' }],
+          columns: [{ name: 'id' }, { name: 'y_id' }]
+        )
+      end
+      let(:node_y) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'node_y', primary_key: 'id',
+          belongs_tos: [{ table_name: 'node_x', foreign_key: 'x_id' }],
+          columns: [{ name: 'id' }, { name: 'x_id' }]
+        )
+      end
+      let(:all_tables) { [node_x, node_y, schema_migrations] }
+
+      it 'classifies both members :unscopable without looping' do
+        expect(described_class.scope_category('node_x', table_by_name, dump_target, logger)).to eq(:unscopable)
+        expect(described_class.scope_category('node_y', table_by_name, dump_target, logger)).to eq(:unscopable)
+      end
+    end
+
+    context 'a table with two scopable belongs_to parents' do
+      # Each hub is scoped via its own reverse_scope (so neither is directly
+      # scoped and via_path cannot terminate on it), and `child` belongs_to both.
+      # The forward rescue only supports a single unambiguous parent, so it bails
+      # rather than guessing which parent's ids to constrain on.
+      let(:hub_a) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'hub_a', primary_key: 'id', belongs_tos: [],
+          reverse_scope: { via: [{ table: 'ref_a', column: 'hub_a_id' }] },
+          columns: [{ name: 'id' }]
+        )
+      end
+      let(:ref_a) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'ref_a', primary_key: 'id',
+          belongs_tos: [{ table_name: 'hub_a', foreign_key: 'hub_a_id' }],
+          columns: [{ name: 'id' }, { name: 'hub_a_id' }, { name: 'tenant_id' }]
+        )
+      end
+      let(:hub_b) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'hub_b', primary_key: 'id', belongs_tos: [],
+          reverse_scope: { via: [{ table: 'ref_b', column: 'hub_b_id' }] },
+          columns: [{ name: 'id' }]
+        )
+      end
+      let(:ref_b) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'ref_b', primary_key: 'id',
+          belongs_tos: [{ table_name: 'hub_b', foreign_key: 'hub_b_id' }],
+          columns: [{ name: 'id' }, { name: 'hub_b_id' }, { name: 'tenant_id' }]
+        )
+      end
+      let(:child) do
+        Exwiw::TableConfig.from_symbol_keys(
+          name: 'child', primary_key: 'id',
+          belongs_tos: [
+            { table_name: 'hub_a', foreign_key: 'hub_a_id' },
+            { table_name: 'hub_b', foreign_key: 'hub_b_id' },
+          ],
+          columns: [{ name: 'id' }, { name: 'hub_a_id' }, { name: 'hub_b_id' }]
+        )
+      end
+      let(:all_tables) { [hub_a, ref_a, hub_b, ref_b, child, schema_migrations] }
+
+      it 'stays :unscopable rather than picking an ambiguous parent' do
+        expect(described_class.scope_category('child', table_by_name, dump_target, logger)).to eq(:unscopable)
+      end
+    end
+
+    def sqlite_adapter
+      Exwiw::Adapter::SqliteAdapter.new(
+        Exwiw::ConnectionConfig.new(
+          adapter: 'sqlite', database_name: 'tmp/test.sqlite3',
+          host: nil, port: nil, user: nil, password: nil
+        ),
+        logger,
+      )
+    end
+  end
 end

--- a/spec/support/ast_factory.rb
+++ b/spec/support/ast_factory.rb
@@ -176,6 +176,61 @@ module AstFactory
     end
   end
 
+  # A multi-hop forward scope cascade: `projects` constrained to `teams`,
+  # `teams` to `companies`, and `companies` to a reverse_scope UNION. This is the
+  # shape the builder emits when a table sits two `belongs_to` hops below a
+  # reverse-scoped table, so it exercises a SelectSubquery nested inside a
+  # SelectSubquery nested inside a UnionSubquery — i.e. recursive subquery
+  # rendering at three levels. Built directly (not via the builder) so each
+  # adapter's nesting can be asserted in isolation. Adapter-agnostic.
+  def build_multi_hop_nested_in_ast
+    plain = ->(name) { Exwiw::TableColumn.from_symbol_keys(name: name) }
+
+    # Deepest level: the reverse_scope arm `companies` is constrained to.
+    union_arm = QueryAst::Select.new.tap do |q|
+      q.from("memberships")
+      q.select([plain.call("company_id")])
+      q.where(QueryAst::WhereClause.new(column_name: "business_entity_id", operator: :eq, value: [1]))
+      q.where(QueryAst::WhereClause.new(column_name: "company_id", operator: :not_null))
+    end
+
+    companies_query = QueryAst::Select.new.tap do |q|
+      q.from("companies")
+      q.select([plain.call("id")])
+      q.where(
+        QueryAst::WhereClause.new(
+          column_name: "id",
+          operator: :in_subquery,
+          value: QueryAst::UnionSubquery.new(queries: [union_arm]),
+        )
+      )
+    end
+
+    teams_query = QueryAst::Select.new.tap do |q|
+      q.from("teams")
+      q.select([plain.call("id")])
+      q.where(
+        QueryAst::WhereClause.new(
+          column_name: "company_id",
+          operator: :in_subquery,
+          value: QueryAst::SelectSubquery.new(query: companies_query),
+        )
+      )
+    end
+
+    QueryAst::Select.new.tap do |ast|
+      ast.from("projects")
+      ast.select_all!
+      ast.where(
+        QueryAst::WhereClause.new(
+          column_name: "team_id",
+          operator: :in_subquery,
+          value: QueryAst::SelectSubquery.new(query: teams_query),
+        )
+      )
+    end
+  end
+
   def build_order_items_ast(order_items_filter_opt = nil, orders_filter_opt = nil)
     order_items_table = order_items_table(adapter_name)
 


### PR DESCRIPTION
## 概要

scope-column モードの forward scope（`via_scoped_parent`）が belongs_to 1 ホップで打ち切られていた問題を修正します。

スコープ列を持たないテーブルは belongs_to 親の絞り込み済み ID（`fk IN (SELECT parent.pk FROM <親の scoped query>)`）で絞ります。しかし親自身が「さらにその親」経由でのみスコープできる場合（例: `users ← end_users ← end_user_profiles` のように reverse/forward でスコープされるテーブルの 2 ホップ以上下）、親が再構築時に未絞り込みで返り、子が `:unscopable` 判定になっていました。結果として `scope_exempt`（全件ダンプ）が必要になり、prune で取り除いたはずの肥大化が再発します。

## 変更内容

- boolean の単一ホップ制限（`allow_forward`）を `forward_path`（現在 forward 解決中のテーブル列）ガードに置き換え。親の再構築時も forward scope を有効に保ち、現在のテーブルを path に追加することで **N 階層カスケード**し、ネストした `IN (subquery)` を生成します。
- 終了条件は belongs_to の循環のみ。candidate の親が既に path 上にあれば打ち切り `:unscopable` にフォールバックします。
- 単一・一意な親ルール、polymorphic スキップ、reverse arm が自テーブルへ循環しないガードは従来どおり不変。
- SQL アダプタのみ。

## テスト

- 多段 forward カスケード: `companies ← teams ← projects ← tasks` が全て `:via_scoped_parent` 判定になり、SQL が 1 ホップごとにネストすることを検証
- 循環終了: `a → b → a` が無限ループせず両者 `:unscopable`
- 単一親ガード維持: スコープ可能な親が 2 つあるテーブルは `:unscopable`
- 3 アダプタ（sqlite / mysql / postgresql）で 3 段ネスト subquery が再帰描画されることを検証
- 既存 550 + 新規 9 = 559 examples green

🤖 Generated with [Claude Code](https://claude.com/claude-code)