### PR TITLE
fix: materialize scope id-sets as derived-table JOINs (avoid correlated full-scan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scope id-sets are materialized and probed by JOIN instead of `<col> IN (subquery)`, removing a correlated full-scan on large tables.** The three id-set scope shapes — the multi-referencer `reverse_scope` `UNION`, the single-referencer reverse/`referenced_by` extraction, and the multi-hop forward (`via_scoped_parent`) cascade — were emitted as `<col> IN (<subquery>)`. On a large global-identity table (e.g. `users`) MySQL cannot turn a `UNION` subquery into a materialized semi-join and falls back to its IN-to-`EXISTS` rewrite: a correlated `DEPENDENT SUBQUERY`/`DEPENDENT UNION` re-evaluated **per outer row**, so the driving table is full-scanned and the union re-run for every row (the plan that ran for minutes and timed out on a production-scale identity table, even for an empty tenant). These clauses are now lifted into a `JOIN` against a materialized derived table — `JOIN (SELECT DISTINCT src.<id> AS exwiw_scope_id FROM (<id-set subquery>) AS src) AS ids ON <table>.<col> = ids.exwiw_scope_id` — so the engine evaluates the id set **once** (the `DISTINCT` makes the derived table non-mergeable, hence materialized) and probes the outer table by primary key. The `DISTINCT` also dedups, so the result set is identical to the old `IN` form; the cascade nests the same way (each level materialized once); NULL exclusion, the forward-path cycle guard, single-parent/polymorphic skips, and PostgreSQL's `uuid`/`varchar` `::text` reconciliation are all preserved. All three SQL adapters (mysql / postgresql / sqlite). See the [README](README.md#why-a-join-not-in-subquery).
+
 ## [0.8.3] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -179,15 +179,18 @@ Each table is resolved as follows:
   nearest such table and applies the scope filter there (the same join machinery
   the single-target mode uses).
 - **`belongs_to` a parent that is itself scoped but carries no scope column of its
-  own** → exwiw constrains this table to the parent's in-scope ids via a subquery
-  (`fk IN (SELECT parent.pk FROM <parent's scoped query>)`). This covers a *hub*
-  table that has no scope column and is scoped only because an extractable child
-  references it (see referenced-by below): the hub's other `belongs_to` children
-  ride along to just the in-scope rows instead of being dumped in full. The parent
-  itself may be scoped the same way, so this **cascades across multiple hops**
-  (each a single unambiguous scopable parent) and the subquery nests
-  correspondingly; the recursion terminates on a genuine `belongs_to` cycle (a
-  table already on the path is left `:unscopable` rather than looped on).
+  own** → exwiw constrains this table to the parent's in-scope ids by joining it to
+  the parent's scoped query, materialized as a derived table
+  (`JOIN (SELECT DISTINCT parent.pk … FROM <parent's scoped query>) … ON fk = …`).
+  This covers a *hub* table that has no scope column and is scoped only because an
+  extractable child references it (see referenced-by below): the hub's other
+  `belongs_to` children ride along to just the in-scope rows instead of being dumped
+  in full. The parent itself may be scoped the same way, so this **cascades across
+  multiple hops** (each a single unambiguous scopable parent) and the derived-table
+  JOINs nest correspondingly; the recursion terminates on a genuine `belongs_to`
+  cycle (a table already on the path is left `:unscopable` rather than looped on).
+  (See [Why a JOIN, not `IN (subquery)`](#why-a-join-not-in-subquery) for the
+  materialization rationale.)
 - **Cannot be scoped at all** (no scope column and no path to one) → exwiw
   **aborts** and lists the offending tables, so an unscoped table is never silently
   dumped in full. For each, either declare a `scope_column`, add a `belongs_to`
@@ -568,15 +571,19 @@ The same type filter is applied on the join path — and in the matching `delete
 ActiveStorage is handled automatically — no ActiveStorage-specific configuration is required. The `has_one_attached` / `has_many_attached` macros don't add a column to the owning model; they generate ordinary associations that exwiw already understands:
 
 - **`active_storage_attachments`** is the polymorphic join row (`belongs_to :record, polymorphic: true` + `belongs_to :blob`). `exwiw:schema:generate` expands the polymorphic `record` into one `belongs_to` per model that declared `has_*_attached` (found via the generated `has_* ..., as: :record` reflections), exactly like any other [polymorphic `belongs_to`](#polymorphic-belongs_to). So only the attachments whose owner is among the dumped rows are extracted.
-- **`active_storage_blobs`** has no `belongs_to` of its own (attachments point *at* it), so it has no path to the dump target. exwiw narrows it via **reverse / "referenced_by" extraction**: a parent table referenced by exactly one constrained, non-polymorphic child is constrained to just the referenced ids instead of dumping every row:
+- **`active_storage_blobs`** has no `belongs_to` of its own (attachments point *at* it), so it has no path to the dump target. exwiw narrows it via **reverse / "referenced_by" extraction**: a parent table referenced by exactly one constrained, non-polymorphic child is constrained to just the referenced ids instead of dumping every row. The id set is materialized once and joined back (see [Why a JOIN, not `IN (subquery)`](#why-a-join-not-in-subquery)):
 
   ```sql
   SELECT active_storage_blobs.* FROM active_storage_blobs
-  WHERE active_storage_blobs.id IN (
-    SELECT active_storage_attachments.blob_id FROM active_storage_attachments
-    WHERE active_storage_attachments.record_id IN (/* owner subquery */)
-      AND active_storage_attachments.record_type = '...'
-  )
+  JOIN (
+    SELECT DISTINCT exwiw_scope_src_0.blob_id AS exwiw_scope_id
+    FROM (
+      SELECT active_storage_attachments.blob_id FROM active_storage_attachments
+      WHERE active_storage_attachments.record_id IN (/* owner subquery */)
+        AND active_storage_attachments.record_type = '...'
+    ) AS exwiw_scope_src_0
+  ) AS exwiw_scope_ids_0
+    ON active_storage_blobs.id = exwiw_scope_ids_0.exwiw_scope_id
   ```
 
   `active_storage_variant_records` also references blobs, but since it has no path of its own to the dump target it doesn't constrain anything and is ignored as a referencer — blobs stays narrowed to the attachment-referenced ids. (A parent referenced by *multiple* constrained children currently falls back to dumping all of its rows.)
@@ -603,18 +610,22 @@ The automatic reverse extraction above narrows a table referenced by **exactly o
 }
 ```
 
-produces (each arm reuses that referencer's own scope, so a per-tenant run keeps only that tenant's ids):
+produces (each arm reuses that referencer's own scope, so a per-tenant run keeps only that tenant's ids; the `UNION` id set is materialized once and joined back — see [Why a JOIN, not `IN (subquery)`](#why-a-join-not-in-subquery)):
 
 ```sql
 SELECT users.* FROM users
-WHERE users.id IN (
-  SELECT customers.user_id FROM customers WHERE <customers' scope> AND customers.user_id IS NOT NULL
-  UNION
-  SELECT staff.user_id FROM staff WHERE <staff' scope> AND staff.user_id IS NOT NULL
-  UNION
-  SELECT business_entity_customers.kantan_yoyaku_user_id FROM business_entity_customers
-    WHERE <…' scope> AND business_entity_customers.kantan_yoyaku_user_id IS NOT NULL
-)
+JOIN (
+  SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id
+  FROM (
+    SELECT customers.user_id FROM customers WHERE <customers' scope> AND customers.user_id IS NOT NULL
+    UNION
+    SELECT staff.user_id FROM staff WHERE <staff' scope> AND staff.user_id IS NOT NULL
+    UNION
+    SELECT business_entity_customers.kantan_yoyaku_user_id FROM business_entity_customers
+      WHERE <…' scope> AND business_entity_customers.kantan_yoyaku_user_id IS NOT NULL
+  ) AS exwiw_scope_src_0
+) AS exwiw_scope_ids_0
+  ON users.id = exwiw_scope_ids_0.exwiw_scope_id
 ```
 
 Notes:
@@ -624,6 +635,19 @@ Notes:
 - **NULLs are excluded** per arm (`IS NOT NULL`).
 - **Satellites need no config.** A table that `belongs_to` the reverse-scoped table (e.g. `end_users.id → users.id`, or `identities.user_id → users.id`) tightens to the kept ids automatically through the normal cascade — only the reverse-scoped table itself declares `reverse_scope`. The cascade is **multi-hop**, so a table several `belongs_to` hops below the reverse-scoped table (e.g. `end_user_profiles → end_users → users`) also tightens automatically, with no config of its own.
 - Works in both single-target and scope-column mode. Polymorphic foreign keys are not eligible as anchors (the named `column` is always a concrete column).
+
+### Why a JOIN, not `IN (subquery)`
+
+Every scope id-set above — the multi-referencer `reverse_scope` `UNION`, the single-referencer reverse extraction, and the multi-hop forward cascade — is emitted as a `JOIN` to a `SELECT DISTINCT` derived table rather than `<col> IN (<subquery>)`:
+
+```sql
+… JOIN (SELECT DISTINCT src.<id> AS exwiw_scope_id FROM (<id-set subquery>) AS src) AS ids
+    ON <table>.<col> = ids.exwiw_scope_id
+```
+
+Both forms select the **same rows** — the `DISTINCT` dedups, so the join never fans out — but the query plans differ sharply on a large table. As `<col> IN (… UNION …)`, MySQL cannot turn a `UNION` subquery into a materialized semi-join and falls back to its IN-to-`EXISTS` rewrite: a **correlated `DEPENDENT SUBQUERY`** re-evaluated for every outer row, i.e. a full scan of the (potentially huge) outer table multiplied by the cost of the union. The derived-table form forces the engine to evaluate the id set **once** (the `DISTINCT` makes the derived table non-mergeable, hence materialized) and then probe the outer table by its primary key. On a global-identity table such as `users` this is the difference between a full table scan and an index lookup; the cascade nests the same way, so each level is materialized once instead of being re-evaluated by the level above.
+
+All three SQL adapters (mysql / postgresql / sqlite) emit this shape. PostgreSQL additionally reconciles a `uuid`/`varchar` type mismatch by casting the join key and the projected id to `text`, exactly as the old `IN` form did.
 
 ### Rails-managed tables (special `type` values)
 

--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -246,7 +246,10 @@ module Exwiw
       # Split an outer query's WHERE clauses into the scope id-set clauses to
       # lift into a materialized derived-table JOIN (see each adapter's
       # #compile_scope_join) and the remaining plain clauses (kept in WHERE).
-      # Returns [scope_clauses, plain_clauses], preserving order.
+      # Returns [scope_clauses, plain_clauses]; #partition keeps each clause in
+      # its original order *within* its own group. The two groups are emitted in
+      # different SQL positions (a JOIN vs the WHERE), so their interleaving is
+      # irrelevant — only the order within each group matters, and that is kept.
       private def partition_scope_clauses(where_clauses)
         where_clauses.partition { |where_clause| scope_subquery_clause?(where_clause) }
       end

--- a/lib/exwiw/adapter.rb
+++ b/lib/exwiw/adapter.rb
@@ -242,6 +242,40 @@ module Exwiw
       private def null_preserving(ast, column, masked_expr)
         "CASE WHEN #{ast.from_table_name}.#{column.name} IS NOT NULL THEN #{masked_expr} ELSE NULL END"
       end
+
+      # Split an outer query's WHERE clauses into the scope id-set clauses to
+      # lift into a materialized derived-table JOIN (see each adapter's
+      # #compile_scope_join) and the remaining plain clauses (kept in WHERE).
+      # Returns [scope_clauses, plain_clauses], preserving order.
+      private def partition_scope_clauses(where_clauses)
+        where_clauses.partition { |where_clause| scope_subquery_clause?(where_clause) }
+      end
+
+      # Whether a WHERE clause is a scope id-set probe that should be lifted into
+      # a JOIN against a materialized derived table. Only the SelectSubquery /
+      # UnionSubquery shapes (reverse_scope UNION, forward cascade, single
+      # referenced_by) qualify: they project over potentially huge tables and, as
+      # `<col> IN (subquery)`, can degrade into a correlated DEPENDENT SUBQUERY
+      # re-evaluated per outer row. The flat ids_field `Subquery` is deliberately
+      # left as a plain IN — it is a small, bounded, uncorrelated probe.
+      private def scope_subquery_clause?(where_clause)
+        where_clause.is_a?(Exwiw::QueryAst::WhereClause) &&
+          where_clause.operator == :in_subquery &&
+          (where_clause.value.is_a?(Exwiw::QueryAst::SelectSubquery) ||
+            where_clause.value.is_a?(Exwiw::QueryAst::UnionSubquery))
+      end
+
+      # The bare name of the single column a scope subquery projects, used to
+      # reference it inside the materialized derived table. For a UNION the
+      # output column name comes from the first arm.
+      private def subquery_projection_name(subquery)
+        case subquery
+        when Exwiw::QueryAst::SelectSubquery
+          subquery.query.columns.first.name
+        when Exwiw::QueryAst::UnionSubquery
+          subquery.queries.first.columns.first.name
+        end
+      end
     end
 
     # @params [Exwiw::QueryAst] query_ast

--- a/lib/exwiw/adapter/mysql_adapter.rb
+++ b/lib/exwiw/adapter/mysql_adapter.rb
@@ -229,11 +229,18 @@ module Exwiw
       def compile_ast(query_ast, count_only: false)
         raise NotImplementedError unless query_ast.is_a?(Exwiw::QueryAst::Select)
 
+        # Lift scope id-set clauses (reverse_scope UNION / forward cascade /
+        # single referenced_by) out of `WHERE <col> IN (subquery)` and into a
+        # JOIN against a materialized derived table. See #compile_scope_join.
+        scope_clauses, plain_where_clauses = partition_scope_clauses(query_ast.where_clauses)
+
         sql = "SELECT "
         sql += if count_only
                  "COUNT(*)"
                elsif query_ast.select_all
-                 "*"
+                 # A lifted scope JOIN brings a derived table into FROM, so a bare
+                 # `*` would also project its column. Qualify to this table's own.
+                 scope_clauses.any? ? "#{query_ast.from_table_name}.*" : "*"
                else
                  query_ast.columns.map { |col| compile_column_name(query_ast, col) }.join(', ')
                end
@@ -256,12 +263,41 @@ module Exwiw
           end
         end
 
-        if query_ast.where_clauses.any?
+        scope_clauses.each_with_index do |where_clause, idx|
+          sql += " #{compile_scope_join(query_ast.from_table_name, where_clause, idx)}"
+        end
+
+        if plain_where_clauses.any?
           sql += " WHERE "
-          sql += query_ast.where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
+          sql += plain_where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
         end
 
         sql
+      end
+
+      # Render a scope id-set clause as a JOIN to a materialized derived table:
+      #
+      #   JOIN (SELECT DISTINCT src.<proj> AS exwiw_scope_id
+      #         FROM (<subquery>) AS src) AS ids
+      #     ON <table>.<col> = ids.exwiw_scope_id
+      #
+      # The DISTINCT makes the derived table non-mergeable, so MySQL materializes
+      # the id-set once and probes this table by it (PK/index lookup) — instead
+      # of full-scanning this table and re-evaluating a correlated
+      # `IN (… UNION …)` per row (the DEPENDENT SUBQUERY / IN-to-EXISTS fallback,
+      # which a UNION subquery cannot be turned into a materialized semi-join).
+      # DISTINCT also dedups, so the join never fans out: the row set is identical
+      # to `<col> IN (subquery)`.
+      private def compile_scope_join(from_table_name, where_clause, idx)
+        subquery = where_clause.value
+        projection = subquery_projection_name(subquery)
+        src_alias = "exwiw_scope_src_#{idx}"
+        ids_alias = "exwiw_scope_ids_#{idx}"
+        outer_key = "#{from_table_name}.#{where_clause.column_name}"
+
+        "JOIN (SELECT DISTINCT #{src_alias}.#{projection} AS exwiw_scope_id " \
+          "FROM (#{compile_subquery(subquery)}) AS #{src_alias}) AS #{ids_alias} " \
+          "ON #{outer_key} = #{ids_alias}.exwiw_scope_id"
       end
 
       private def compile_where_condition(where_clause, table_name)

--- a/lib/exwiw/adapter/postgresql_adapter.rb
+++ b/lib/exwiw/adapter/postgresql_adapter.rb
@@ -301,9 +301,16 @@ module Exwiw
       def compile_ast(query_ast, select_cast_to: nil)
         raise NotImplementedError unless query_ast.is_a?(Exwiw::QueryAst::Select)
 
+        # Lift scope id-set clauses (reverse_scope UNION / forward cascade /
+        # single referenced_by) out of `WHERE <col> IN (subquery)` and into a
+        # JOIN against a materialized derived table. See #compile_scope_join.
+        scope_clauses, plain_where_clauses = partition_scope_clauses(query_ast.where_clauses)
+
         sql = "SELECT "
         sql += if query_ast.select_all
-                 "*"
+                 # A lifted scope JOIN brings a derived table into FROM, so a bare
+                 # `*` would also project its column. Qualify to this table's own.
+                 scope_clauses.any? ? "#{query_ast.from_table_name}.*" : "*"
                else
                  cols = query_ast.columns.map { |col| compile_column_name(query_ast, col) }
                  cols = cols.map { |c| "#{c}::#{select_cast_to}" } if select_cast_to
@@ -337,12 +344,43 @@ module Exwiw
           end
         end
 
-        if query_ast.where_clauses.any?
+        scope_clauses.each_with_index do |where_clause, idx|
+          sql += " #{compile_scope_join(query_ast.from_table_name, where_clause, idx)}"
+        end
+
+        if plain_where_clauses.any?
           sql += " WHERE "
-          sql += query_ast.where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
+          sql += plain_where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
         end
 
         sql
+      end
+
+      # Render a scope id-set clause as a JOIN to a materialized derived table
+      # (see MysqlAdapter#compile_scope_join for the full rationale). The DISTINCT
+      # forces the engine to materialize the id-set once and probe this table by
+      # it, instead of full-scanning and re-evaluating a correlated subquery per
+      # row; it also dedups, so the join is row-for-row identical to
+      # `<col> IN (subquery)`.
+      #
+      # Type reconciliation mirrors the old IN form: when the outer column and
+      # the projected id clash (e.g. uuid vs varchar), #compile_subquery already
+      # casts every arm to text, so the derived `exwiw_scope_id` is text and the
+      # outer key is cast to match.
+      private def compile_scope_join(from_table_name, where_clause, idx)
+        subquery = where_clause.value
+        projection = subquery_projection_name(subquery)
+        src_alias = "exwiw_scope_src_#{idx}"
+        ids_alias = "exwiw_scope_ids_#{idx}"
+
+        inner_sql = compile_subquery(subquery, outer_table: from_table_name, outer_column: where_clause.column_name)
+        cast_to = subquery_cast_to(subquery, from_table_name, where_clause.column_name)
+        outer_key = "#{from_table_name}.#{where_clause.column_name}"
+        outer_key = "#{outer_key}::#{cast_to}" if cast_to
+
+        "JOIN (SELECT DISTINCT #{src_alias}.#{projection} AS exwiw_scope_id " \
+          "FROM (#{inner_sql}) AS #{src_alias}) AS #{ids_alias} " \
+          "ON #{outer_key} = #{ids_alias}.exwiw_scope_id"
       end
 
       private def compile_where_condition(where_clause, table_name)

--- a/lib/exwiw/adapter/sqlite_adapter.rb
+++ b/lib/exwiw/adapter/sqlite_adapter.rb
@@ -198,11 +198,18 @@ module Exwiw
       def compile_ast(query_ast, count_only: false)
         raise NotImplementedError unless query_ast.is_a?(Exwiw::QueryAst::Select)
 
+        # Lift scope id-set clauses (reverse_scope UNION / forward cascade /
+        # single referenced_by) out of `WHERE <col> IN (subquery)` and into a
+        # JOIN against a materialized derived table. See #compile_scope_join.
+        scope_clauses, plain_where_clauses = partition_scope_clauses(query_ast.where_clauses)
+
         sql = "SELECT "
         sql += if count_only
                  "COUNT(*)"
                elsif query_ast.select_all
-                 "*"
+                 # A lifted scope JOIN brings a derived table into FROM, so a bare
+                 # `*` would also project its column. Qualify to this table's own.
+                 scope_clauses.any? ? "#{query_ast.from_table_name}.*" : "*"
                else
                  query_ast.columns.map { |col| compile_column_name(query_ast, col) }.join(', ')
                end
@@ -225,12 +232,34 @@ module Exwiw
           end
         end
 
-        if query_ast.where_clauses.any?
+        scope_clauses.each_with_index do |where_clause, idx|
+          sql += " #{compile_scope_join(query_ast.from_table_name, where_clause, idx)}"
+        end
+
+        if plain_where_clauses.any?
           sql += " WHERE "
-          sql += query_ast.where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
+          sql += plain_where_clauses.map { |where| compile_where_condition(where, query_ast.from_table_name) }.join(' AND ')
         end
 
         sql
+      end
+
+      # Render a scope id-set clause as a JOIN to a materialized derived table
+      # (see MysqlAdapter#compile_scope_join for the full rationale). The DISTINCT
+      # forces the engine to materialize the id-set once and probe this table by
+      # it, instead of full-scanning and re-evaluating a correlated subquery per
+      # row; it also dedups, so the join is row-for-row identical to
+      # `<col> IN (subquery)`.
+      private def compile_scope_join(from_table_name, where_clause, idx)
+        subquery = where_clause.value
+        projection = subquery_projection_name(subquery)
+        src_alias = "exwiw_scope_src_#{idx}"
+        ids_alias = "exwiw_scope_ids_#{idx}"
+        outer_key = "#{from_table_name}.#{where_clause.column_name}"
+
+        "JOIN (SELECT DISTINCT #{src_alias}.#{projection} AS exwiw_scope_id " \
+          "FROM (#{compile_subquery(subquery)}) AS #{src_alias}) AS #{ids_alias} " \
+          "ON #{outer_key} = #{ids_alias}.exwiw_scope_id"
       end
 
       private def compile_where_condition(where_clause, table_name)

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -282,12 +282,16 @@ module Exwiw
           before_plan = adapter.send(:connection).query("EXPLAIN #{in_sql}").rows.flatten.join("\n").downcase
           after_plan = adapter.explain(ast).downcase
 
-          # Before: MySQL turns `IN (… UNION …)` into a per-row correlated
-          # subquery (DEPENDENT SUBQUERY / DEPENDENT UNION). Present in both the
-          # classic-tabular `select_type` and the tree-format wording.
+          # `IN (… UNION …)` makes MySQL re-evaluate the subquery per outer row.
+          # exwiw runs a plain `EXPLAIN` (no FORMAT=); its default rendering is
+          # server-version-dependent — tree-format on MySQL 8.3+/9 (this suite's
+          # server), classic-tabular on older — but the per-row plan is flagged
+          # "dependent" in both ("dependent" / "DEPENDENT SUBQUERY"), so the
+          # before/after on that substring is the format-robust signal.
           expect(before_plan).to include("dependent")
-          # After: the union is evaluated once (materialized) and users is reached
-          # by probing that id-set — no correlated subquery remains.
+          # After: the union is evaluated once and users is reached by probing
+          # that id-set — no correlated subquery remains. The tree-format plan
+          # this server returns also names the one-shot id-set ("Materialize").
           expect(after_plan).not_to include("dependent")
           expect(after_plan).to match(/materiali/)
         end

--- a/spec/adapter/mysql_adapter_spec.rb
+++ b/spec/adapter/mysql_adapter_spec.rb
@@ -229,12 +229,14 @@ module Exwiw
         context "select query with a multi-referencer reverse-scope UNION subquery" do
           let(:sql) { adapter.compile_ast(build_reverse_scope_union_ast) }
 
-          it "compiles to IN (… UNION …) of NULL-excluding projected selects" do
+          it "materializes the UNION id-set as a derived-table JOIN of NULL-excluding projected selects" do
             expect(sql).to eq(
-              "SELECT * FROM users WHERE users.id IN (" \
+              "SELECT users.* FROM users JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (" \
               "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 1 AND customers.user_id IS NOT NULL " \
               "UNION " \
-              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL)"
+              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
             )
           end
         end
@@ -242,14 +244,52 @@ module Exwiw
         context "select query with a three-level nested IN subquery (multi-hop forward cascade)" do
           let(:sql) { adapter.compile_ast(build_multi_hop_nested_in_ast) }
 
-          it "renders the subqueries recursively at every level" do
+          it "nests a materialized derived-table JOIN at every level" do
             expect(sql).to eq(
-              "SELECT * FROM projects WHERE projects.team_id IN (" \
-              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
-              "SELECT companies.id FROM companies WHERE companies.id IN (" \
-              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+              "SELECT projects.* FROM projects JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT teams.id FROM teams JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT companies.id FROM companies JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.company_id AS exwiw_scope_id FROM (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON companies.id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON teams.company_id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON projects.team_id = exwiw_scope_ids_0.exwiw_scope_id"
             )
           end
+        end
+      end
+
+      # The reverse_scope / forward-cascade id-set is emitted as a JOIN to a
+      # materialized (SELECT DISTINCT) derived table rather than `<col> IN
+      # (subquery)`. These run against the real seed DB to prove the rewrite
+      # (a) returns the same rows and (b) no longer compiles to a correlated
+      # DEPENDENT SUBQUERY (the per-row re-evaluation that timed out in prod).
+      describe "scope id-set materialization (derived-table JOIN)" do
+        let(:ast) { build_users_reverse_scope_over_seed_ast }
+        let(:in_sql) { users_reverse_scope_over_seed_in_sql }
+
+        it "returns the same users as the equivalent IN-subquery (result-set equivalence)" do
+          new_ids = adapter.execute(ast).to_a.map { |row| row.first.to_s }.sort
+          old_ids = adapter.send(:connection).query(in_sql).rows.map { |row| row.first.to_s }.sort
+
+          expect(new_ids).not_to be_empty
+          expect(new_ids).to eq(old_ids)
+        end
+
+        it "EXPLAINs as a materialized id-set with no correlated DEPENDENT SUBQUERY" do
+          before_plan = adapter.send(:connection).query("EXPLAIN #{in_sql}").rows.flatten.join("\n").downcase
+          after_plan = adapter.explain(ast).downcase
+
+          # Before: MySQL turns `IN (… UNION …)` into a per-row correlated
+          # subquery (DEPENDENT SUBQUERY / DEPENDENT UNION). Present in both the
+          # classic-tabular `select_type` and the tree-format wording.
+          expect(before_plan).to include("dependent")
+          # After: the union is evaluated once (materialized) and users is reached
+          # by probing that id-set — no correlated subquery remains.
+          expect(after_plan).not_to include("dependent")
+          expect(after_plan).to match(/materiali/)
         end
       end
 

--- a/spec/adapter/postgresql_adapter_spec.rb
+++ b/spec/adapter/postgresql_adapter_spec.rb
@@ -144,6 +144,20 @@ module Exwiw
         end
       end
 
+      # The reverse_scope id-set is emitted as a JOIN to a materialized
+      # (SELECT DISTINCT) derived table; run against the real seed DB to prove
+      # it returns the same rows as the pre-fix `<col> IN (subquery)` form.
+      describe "scope id-set materialization (derived-table JOIN)" do
+        it "returns the same users as the equivalent IN-subquery (result-set equivalence)" do
+          ast = build_users_reverse_scope_over_seed_ast
+          new_ids = adapter.execute(ast).to_a.map { |row| row.first.to_s }.sort
+          old_ids = adapter.send(:connection).exec(users_reverse_scope_over_seed_in_sql).values.map { |row| row.first.to_s }.sort
+
+          expect(new_ids).not_to be_empty
+          expect(new_ids).to eq(old_ids)
+        end
+      end
+
       describe "#execute" do
         context "simple select query" do
           # #execute now returns a streaming Enumerable (single-row mode), so
@@ -391,8 +405,8 @@ module Exwiw
           end
         end
 
-        context "compile_where_condition with :in_subquery (SelectSubquery) and uuid mismatch" do
-          it "casts outer key and inner select column" do
+        context "compile_ast with :in_subquery (SelectSubquery) and uuid mismatch" do
+          it "casts the outer join key and the inner projected column" do
             allow(adapter).to receive(:column_pg_type).with("shops", "id").and_return('uuid')
             allow(adapter).to receive(:column_pg_type).with("users", "shop_id").and_return('varchar')
 
@@ -422,7 +436,8 @@ module Exwiw
             end
 
             sql = adapter.compile_ast(ast)
-            expect(sql).to include("shops.id::text IN (SELECT users.shop_id::text FROM users")
+            expect(sql).to include("SELECT users.shop_id::text FROM users")
+            expect(sql).to include("ON shops.id::text = exwiw_scope_ids_0.exwiw_scope_id")
           end
         end
 
@@ -437,39 +452,47 @@ module Exwiw
         end
 
         context "compile_ast with a UnionSubquery and matching arm types" do
-          it "does not cast any arm" do
+          it "materializes the UNION as a derived-table JOIN, casting nothing" do
             sql = adapter.compile_ast(build_reverse_scope_union_ast)
             expect(sql).to eq(
-              "SELECT * FROM users WHERE users.id IN (" \
+              "SELECT users.* FROM users JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (" \
               "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 1 AND customers.user_id IS NOT NULL " \
               "UNION " \
-              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL)"
+              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
             )
             expect(sql).not_to include("::text")
           end
         end
 
         context "compile_ast with a UnionSubquery where a later arm's type differs" do
-          it "casts the outer key AND every arm to ::text (not just the first)" do
+          it "casts the outer join key AND every arm to ::text (not just the first)" do
             allow(adapter).to receive(:column_pg_type).with("users", "id").and_return('uuid')
             allow(adapter).to receive(:column_pg_type).with("customers", "user_id").and_return('uuid')
             allow(adapter).to receive(:column_pg_type).with("staff", "user_id").and_return('varchar')
 
             sql = adapter.compile_ast(build_reverse_scope_union_ast)
-            expect(sql).to include("users.id::text IN (")
+            expect(sql).to include("ON users.id::text = exwiw_scope_ids_0.exwiw_scope_id")
             expect(sql).to include("SELECT customers.user_id::text FROM customers")
             expect(sql).to include("SELECT staff.user_id::text FROM staff")
           end
         end
 
         context "compile_ast with a three-level nested IN subquery (multi-hop forward cascade)" do
-          it "renders the subqueries recursively at every level (matching types, no cast)" do
+          it "nests a materialized derived-table JOIN at every level (matching types, no cast)" do
             sql = adapter.compile_ast(build_multi_hop_nested_in_ast)
             expect(sql).to eq(
-              "SELECT * FROM projects WHERE projects.team_id IN (" \
-              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
-              "SELECT companies.id FROM companies WHERE companies.id IN (" \
-              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+              "SELECT projects.* FROM projects JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT teams.id FROM teams JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT companies.id FROM companies JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.company_id AS exwiw_scope_id FROM (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON companies.id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON teams.company_id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON projects.team_id = exwiw_scope_ids_0.exwiw_scope_id"
             )
             expect(sql).not_to include("::text")
           end

--- a/spec/adapter/sqlite_adapter_spec.rb
+++ b/spec/adapter/sqlite_adapter_spec.rb
@@ -151,12 +151,14 @@ module Exwiw
         context "select query with a multi-referencer reverse-scope UNION subquery" do
           let(:sql) { adapter.compile_ast(build_reverse_scope_union_ast) }
 
-          it "compiles to IN (… UNION …) of NULL-excluding projected selects" do
+          it "materializes the UNION id-set as a derived-table JOIN of NULL-excluding projected selects" do
             expect(sql).to eq(
-              "SELECT * FROM users WHERE users.id IN (" \
+              "SELECT users.* FROM users JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (" \
               "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 1 AND customers.user_id IS NOT NULL " \
               "UNION " \
-              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL)"
+              "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
             )
           end
         end
@@ -164,12 +166,18 @@ module Exwiw
         context "select query with a three-level nested IN subquery (multi-hop forward cascade)" do
           let(:sql) { adapter.compile_ast(build_multi_hop_nested_in_ast) }
 
-          it "renders the subqueries recursively at every level" do
+          it "nests a materialized derived-table JOIN at every level" do
             expect(sql).to eq(
-              "SELECT * FROM projects WHERE projects.team_id IN (" \
-              "SELECT teams.id FROM teams WHERE teams.company_id IN (" \
-              "SELECT companies.id FROM companies WHERE companies.id IN (" \
-              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL)))"
+              "SELECT projects.* FROM projects JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT teams.id FROM teams JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (" \
+              "SELECT companies.id FROM companies JOIN (" \
+              "SELECT DISTINCT exwiw_scope_src_0.company_id AS exwiw_scope_id FROM (" \
+              "SELECT memberships.company_id FROM memberships WHERE memberships.business_entity_id = 1 AND memberships.company_id IS NOT NULL" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON companies.id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON teams.company_id = exwiw_scope_ids_0.exwiw_scope_id" \
+              ") AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON projects.team_id = exwiw_scope_ids_0.exwiw_scope_id"
             )
           end
         end
@@ -191,6 +199,20 @@ module Exwiw
       describe "#query_comment_text" do
         it "strips comment terminators to prevent breaking out of the comment" do
           expect(adapter.query_comment_text("table=foo*/DROP")).not_to include('*/')
+        end
+      end
+
+      # The reverse_scope id-set is emitted as a JOIN to a materialized
+      # (SELECT DISTINCT) derived table; run against the real seed DB to prove
+      # it returns the same rows as the pre-fix `<col> IN (subquery)` form.
+      describe "scope id-set materialization (derived-table JOIN)" do
+        it "returns the same users as the equivalent IN-subquery (result-set equivalence)" do
+          ast = build_users_reverse_scope_over_seed_ast
+          new_ids = adapter.execute(ast).to_a.map { |row| row.first.to_s }.sort
+          old_ids = adapter.send(:connection).execute(users_reverse_scope_over_seed_in_sql).map { |row| row.first.to_s }.sort
+
+          expect(new_ids).not_to be_empty
+          expect(new_ids).to eq(old_ids)
         end
       end
 

--- a/spec/query_ast_builder_spec.rb
+++ b/spec/query_ast_builder_spec.rb
@@ -464,7 +464,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
         ])
       end
 
-      it 'compiles to a nested IN-subquery SELECT for SQLite' do
+      it 'compiles to a materialized derived-table JOIN for SQLite' do
         adapter = Exwiw::Adapter::SqliteAdapter.new(
           Exwiw::ConnectionConfig.new(
             adapter: 'sqlite', database_name: 'tmp/test.sqlite3',
@@ -474,11 +474,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
         )
 
         expect(adapter.compile_ast(built_query_ast)).to eq(
-          'SELECT active_storage_blobs.id, active_storage_blobs.key, active_storage_blobs.filename ' \
-          'FROM active_storage_blobs ' \
-          'WHERE active_storage_blobs.id IN (' \
-          'SELECT active_storage_attachments.blob_id FROM active_storage_attachments ' \
-          "WHERE active_storage_attachments.record_id = 1 AND active_storage_attachments.record_type = 'AsUser')"
+          "SELECT active_storage_blobs.id, active_storage_blobs.key, active_storage_blobs.filename FROM active_storage_blobs JOIN (SELECT DISTINCT exwiw_scope_src_0.blob_id AS exwiw_scope_id FROM (SELECT active_storage_attachments.blob_id FROM active_storage_attachments WHERE active_storage_attachments.record_id = 1 AND active_storage_attachments.record_type = 'AsUser') AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON active_storage_blobs.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
       end
 
@@ -763,12 +759,9 @@ RSpec.describe Exwiw::QueryAstBuilder do
         ])
       end
 
-      it 'compiles to a nested IN-subquery (sqlite)' do
+      it 'compiles to nested materialized derived-table JOINs (sqlite)' do
         expect(sqlite_adapter.compile_ast(build('account_details'))).to eq(
-          'SELECT account_details.id, account_details.account_id, account_details.secret FROM account_details ' \
-          'WHERE account_details.account_id IN (' \
-          'SELECT accounts.id FROM accounts WHERE accounts.id IN (' \
-          "SELECT customers.account_id FROM customers WHERE customers.tenant_id = 't1'))"
+          "SELECT account_details.id, account_details.account_id, account_details.secret FROM account_details JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT accounts.id FROM accounts JOIN (SELECT DISTINCT exwiw_scope_src_0.account_id AS exwiw_scope_id FROM (SELECT customers.account_id FROM customers WHERE customers.tenant_id = 't1') AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON accounts.id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON account_details.account_id = exwiw_scope_ids_0.exwiw_scope_id"
         )
       end
 
@@ -944,12 +937,9 @@ RSpec.describe Exwiw::QueryAstBuilder do
       ])
     end
 
-    it 'compiles users to IN (… UNION …) (sqlite)' do
+    it 'materializes the UNION id-set as a derived-table JOIN (sqlite)' do
       expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-        'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-        "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL " \
-        'UNION ' \
-        "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 'be1' AND staff.user_id IS NOT NULL)"
+        "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL UNION SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 'be1' AND staff.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
       )
     end
 
@@ -962,11 +952,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
     it 'cascades to a satellite that belongs_to users, with no config of its own' do
       expect(sqlite_adapter.compile_ast(build('end_users'))).to eq(
-        'SELECT end_users.id, end_users.nickname FROM end_users WHERE end_users.id IN (' \
-        'SELECT users.id FROM users WHERE users.id IN (' \
-        "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL " \
-        'UNION ' \
-        "SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 'be1' AND staff.user_id IS NOT NULL))"
+        "SELECT end_users.id, end_users.nickname FROM end_users JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT users.id FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL UNION SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 'be1' AND staff.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON end_users.id = exwiw_scope_ids_0.exwiw_scope_id"
       )
     end
 
@@ -980,8 +966,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
       it 'skips the unknown arm with a warning and unions the rest' do
         expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-          'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-          "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL)"
+          "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
         expect(log_output.string).to include("references unknown table 'ghosts'")
       end
@@ -1007,8 +992,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
       it 'skips the unconstrained arm with a warning and unions the rest' do
         expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-          'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-          "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL)"
+          "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
         expect(log_output.string).to include("arm 'audit_logs.user_id' is not scoped")
       end
@@ -1047,10 +1031,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
       it 'projects the arm with its JOIN to the scoped ancestor' do
         expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-          'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-          'SELECT reservations.user_id FROM reservations ' \
-          "JOIN shops ON reservations.shop_id = shops.id AND shops.business_entity_id = 'be1' " \
-          'WHERE reservations.user_id IS NOT NULL)'
+          "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT reservations.user_id FROM reservations JOIN shops ON reservations.shop_id = shops.id AND shops.business_entity_id = 'be1' WHERE reservations.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
       end
     end
@@ -1070,9 +1051,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
       it 'keeps the referencer filter, with IS NOT NULL appended last' do
         expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-          'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-          "SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' " \
-          'AND customers.deleted_at IS NULL AND customers.user_id IS NOT NULL)'
+          "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 'be1' AND customers.deleted_at IS NULL AND customers.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
       end
     end
@@ -1111,10 +1090,7 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
       it 'unions each referencer constrained by the foreign key to the target' do
         expect(sqlite_adapter.compile_ast(build('users'))).to eq(
-          'SELECT users.id, users.name FROM users WHERE users.id IN (' \
-          'SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 1 AND customers.user_id IS NOT NULL ' \
-          'UNION ' \
-          'SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL)'
+          "SELECT users.id, users.name FROM users JOIN (SELECT DISTINCT exwiw_scope_src_0.user_id AS exwiw_scope_id FROM (SELECT customers.user_id FROM customers WHERE customers.business_entity_id = 1 AND customers.user_id IS NOT NULL UNION SELECT staff.user_id FROM staff WHERE staff.business_entity_id = 1 AND staff.user_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON users.id = exwiw_scope_ids_0.exwiw_scope_id"
         )
       end
     end
@@ -1204,24 +1180,13 @@ RSpec.describe Exwiw::QueryAstBuilder do
 
     it 'nests the second hop one level below the reverse_scope UNION (sqlite)' do
       expect(sqlite_adapter.compile_ast(build('projects'))).to eq(
-        'SELECT projects.id, projects.team_id, projects.name FROM projects ' \
-        'WHERE projects.team_id IN (' \
-        'SELECT teams.id FROM teams WHERE teams.company_id IN (' \
-        'SELECT companies.id FROM companies WHERE companies.id IN (' \
-        "SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' " \
-        'AND memberships.company_id IS NOT NULL)))'
+        "SELECT projects.id, projects.team_id, projects.name FROM projects JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT teams.id FROM teams JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT companies.id FROM companies JOIN (SELECT DISTINCT exwiw_scope_src_0.company_id AS exwiw_scope_id FROM (SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' AND memberships.company_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON companies.id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON teams.company_id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON projects.team_id = exwiw_scope_ids_0.exwiw_scope_id"
       )
     end
 
     it 'nests every hop for the deepest table (sqlite)' do
       expect(sqlite_adapter.compile_ast(build('tasks'))).to eq(
-        'SELECT tasks.id, tasks.project_id, tasks.title FROM tasks ' \
-        'WHERE tasks.project_id IN (' \
-        'SELECT projects.id FROM projects WHERE projects.team_id IN (' \
-        'SELECT teams.id FROM teams WHERE teams.company_id IN (' \
-        'SELECT companies.id FROM companies WHERE companies.id IN (' \
-        "SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' " \
-        'AND memberships.company_id IS NOT NULL))))'
+        "SELECT tasks.id, tasks.project_id, tasks.title FROM tasks JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT projects.id FROM projects JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT teams.id FROM teams JOIN (SELECT DISTINCT exwiw_scope_src_0.id AS exwiw_scope_id FROM (SELECT companies.id FROM companies JOIN (SELECT DISTINCT exwiw_scope_src_0.company_id AS exwiw_scope_id FROM (SELECT memberships.company_id FROM memberships WHERE memberships.tenant_id = 't1' AND memberships.company_id IS NOT NULL) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON companies.id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON teams.company_id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON projects.team_id = exwiw_scope_ids_0.exwiw_scope_id) AS exwiw_scope_src_0) AS exwiw_scope_ids_0 ON tasks.project_id = exwiw_scope_ids_0.exwiw_scope_id"
       )
     end
 

--- a/spec/support/ast_factory.rb
+++ b/spec/support/ast_factory.rb
@@ -238,6 +238,10 @@ module AstFactory
   # global-identity shape that motivated materializing the id-set: the old
   # `id IN (… UNION …)` form degrades into a per-row correlated DEPENDENT
   # SUBQUERY on a large `users`, which the derived-table JOIN removes.
+  #
+  # Projects just the primary key (not `select_all!`), so the executed rows line
+  # up column-for-column with the `SELECT users.id` control SQL below and the
+  # equivalence/EXPLAIN assertions don't depend on `users.*`'s column order.
   def build_users_reverse_scope_over_seed_ast
     plain = ->(name) { Exwiw::TableColumn.from_symbol_keys(name: name) }
 
@@ -255,7 +259,7 @@ module AstFactory
 
     QueryAst::Select.new.tap do |ast|
       ast.from("users")
-      ast.select_all!
+      ast.select([plain.call("id")])
       ast.where(
         QueryAst::WhereClause.new(
           column_name: "id",

--- a/spec/support/ast_factory.rb
+++ b/spec/support/ast_factory.rb
@@ -231,6 +231,52 @@ module AstFactory
     end
   end
 
+  # A reverse-scope UNION over tables that actually exist in the seed, so it can
+  # be executed and EXPLAINed against the real databases (the customers/staff
+  # fixtures above are compile-only). `users` is constrained to the union of two
+  # real referencers — orders (scoped to shop 1) and reviews — mirroring the
+  # global-identity shape that motivated materializing the id-set: the old
+  # `id IN (… UNION …)` form degrades into a per-row correlated DEPENDENT
+  # SUBQUERY on a large `users`, which the derived-table JOIN removes.
+  def build_users_reverse_scope_over_seed_ast
+    plain = ->(name) { Exwiw::TableColumn.from_symbol_keys(name: name) }
+
+    orders_arm = QueryAst::Select.new.tap do |q|
+      q.from("orders")
+      q.select([plain.call("user_id")])
+      q.where(QueryAst::WhereClause.new(column_name: "shop_id", operator: :eq, value: [1]))
+      q.where(QueryAst::WhereClause.new(column_name: "user_id", operator: :not_null))
+    end
+    reviews_arm = QueryAst::Select.new.tap do |q|
+      q.from("reviews")
+      q.select([plain.call("user_id")])
+      q.where(QueryAst::WhereClause.new(column_name: "user_id", operator: :not_null))
+    end
+
+    QueryAst::Select.new.tap do |ast|
+      ast.from("users")
+      ast.select_all!
+      ast.where(
+        QueryAst::WhereClause.new(
+          column_name: "id",
+          operator: :in_subquery,
+          value: QueryAst::UnionSubquery.new(queries: [orders_arm, reviews_arm]),
+        )
+      )
+    end
+  end
+
+  # The pre-fix `<col> IN (… UNION …)` shape of #build_users_reverse_scope_over_seed_ast,
+  # projected to just the id. Used as the control in result-set equivalence and
+  # EXPLAIN before/after assertions — the derived-table JOIN must return the same
+  # rows while no longer compiling to a correlated subquery.
+  def users_reverse_scope_over_seed_in_sql
+    "SELECT users.id FROM users WHERE users.id IN (" \
+      "SELECT orders.user_id FROM orders WHERE orders.shop_id = 1 AND orders.user_id IS NOT NULL " \
+      "UNION " \
+      "SELECT reviews.user_id FROM reviews WHERE reviews.user_id IS NOT NULL)"
+  end
+
   def build_order_items_ast(order_items_filter_opt = nil, orders_filter_opt = nil)
     order_items_table = order_items_table(adapter_name)
 


### PR DESCRIPTION
## 概要

`reverse_scope` の UNION、単一参照元の `referenced_by`、多段フォワードカスケード（`via_scoped_parent`）の scope id-set を `<col> IN (<subquery>)` ではなく、マテリアライズした派生テーブルへの JOIN として出力するように変更しました。

## 問題

大規模なグローバル ID テーブル（例: `users`）では、MySQL が `IN (… UNION …)` をマテリアライズ semi-join に変換できず IN-to-EXISTS にフォールバックし、外側の行ごとに再評価される相関サブクエリ（`DEPENDENT SUBQUERY` / `DEPENDENT UNION`）になっていました。駆動表をフルスキャンしつつ UNION を毎行再実行するため、本番規模のテーブルでタイムアウト（空テナントでも発生）していました。

## 変更内容

scope 句を WHERE から外し、JOIN として出力します:

```sql
JOIN (SELECT DISTINCT src.<id> AS exwiw_scope_id
      FROM (<id-set subquery>) AS src) AS ids
  ON <table>.<col> = ids.exwiw_scope_id
```

- `DISTINCT` で派生テーブルが非マージになり、id-set は一度だけマテリアライズされ、外側は PK で probe されます。`DISTINCT` は重複も除去するため行は増えず、結果セットは従来の `IN` と同一です。
- カスケードも同様にネストし、各段が一度だけマテリアライズされます。
- `ids_field` 用の有界な `Subquery` は対象外で、従来どおり `IN` のままです。
- NULL 除外 / フォワードパスのサイクルガード / 単一親・ポリモーフィックのスキップ / PostgreSQL の uuid・varchar の `::text` 変換は維持。`compile_where_condition` / `compile_subquery` は未変更なので `to_bulk_delete` も不変です。
- 対象は SQL 3 アダプタ（mysql / postgresql / sqlite）。

## テスト

- 既存の SQL 形状アサーションを JOIN 形へ更新。
- 実 DB での結果セット等価性（3 アダプタ）: JOIN 形が従来の `IN (… UNION …)` と同じ行を返すことを確認。
- MySQL の EXPLAIN before/after: 旧 `IN` 形は `DEPENDENT` サブクエリになるが、新 JOIN 形は `DEPENDENT` が消え、id-set を一度だけマテリアライズして `users` を probe することを確認。
- 全スイート green（563 examples）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)