### PR TITLE
feat(mongodb): parallel dump で collection ごとの抽出件数サマリーを出力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **The MongoDB fork-parallel dump (`--parallel-workers`) logs a per-collection extracted-record summary on completion.** The serial path already logs each collection's row count inline, but the parallel path previously emitted only an aggregate (`genuine`/`leaves`/`ref_bt` counts). The leaf and `ref_bt` collections are extracted in forked workers whose counts never reached the parent, so the per-collection numbers were unavailable. Each worker now hands its counts back through the same Marshal-sidecar IPC the consumed-leaf `@state` already uses; the parent merges them with the genuine counts it holds and logs one `name: count` line per collection in processing order (matching the `insert-NNN-` file numbering), plus a `total_records` field on the returned stats. This is purely additive metadata — it does not touch the output files, so the byte-identity guarantee is unchanged.
+
 ## [0.8.5] - 2026-06-25
 
 - **`--parallel-workers=N` parallelizes the MongoDB dump across forked processes (opt-in, byte-identical).** When set with `N≥2` on the mongodb adapter's `export`, exwiw runs an inter-collection fork schedule that decodes whole collections in parallel while preserving each collection's natural row order, so the output files are byte-identical to a serial run (same filenames, same content). Collections are classified into three dependency groups — reference data dumped in full (no `belongs_to`), the scoped DAG reachable to the dump target, and non-reachable reference data — which lets the heavy full-dump collections run concurrently with the scoped pass; only a handful of small `@state` hand-offs cross process boundaries. The win needs real cores: it clears ~2× from 4 workers and saturates there. Requires a dump target and a `fork`-capable runtime (CRuby on POSIX); it falls back to the serial path on JRuby/TruffleRuby/Windows or when no target is given. Also settable as `parallel_workers:` in the config file. The default remains the serial dump.

--- a/e2e/test_with_mongodb_parallel.sh
+++ b/e2e/test_with_mongodb_parallel.sh
@@ -68,6 +68,19 @@ if ! grep -q "MongoDB parallel dump with ${WORKERS} worker(s): genuine=2, leaves
 fi
 echo "✓ fork schedule ran with work in all three phases (genuine=2, leaves=2, ref_bt=2)"
 
+# 3b) Assert the per-collection extracted-record summary was logged with the
+# counts collected back from EVERY phase (genuine in the parent, the leaf pool
+# fork, and the ref_bt component fork). The seed is deterministic, so the counts
+# are fixed: shops/products are genuine, brands/regions are leaves, and
+# region_settings/region_locales are the Phase-3 ref_bt component.
+for expected in "shops: 1" "products: 2" "brands: 3" "regions: 2" "region_settings: 2" "region_locales: 3"; do
+  if ! grep -qF "$expected" <<<"$PARALLEL_LOG"; then
+    echo "✗ per-collection summary missing or wrong: expected a '$expected' line"
+    exit 1
+  fi
+done
+echo "✓ per-collection extracted-record summary logged with counts from all phases"
+
 # 4) Byte-identity: the core guarantee of --parallel-workers.
 if diff -r "$SERIAL_DIR" "$PARALLEL_DIR"; then
   echo "✓ parallel output is byte-identical to serial"

--- a/lib/exwiw/mongodb_parallel_dumper.rb
+++ b/lib/exwiw/mongodb_parallel_dumper.rb
@@ -41,6 +41,12 @@ module Exwiw
   # fork is required; callers must check {.available?} and fall back to the serial
   # Runner on JRuby/TruffleRuby/Windows.
   class MongodbParallelDumper
+    # Filename prefix for the per-worker record-count sidecars. Distinct from the
+    # consumed-leaf @state sidecars (`<name>.marshal`) so the two never collide in
+    # the shared sidecar dir and the counts can be globbed back independently.
+    COUNTS_SIDECAR_PREFIX = "__exwiw_counts__"
+    private_constant :COUNTS_SIDECAR_PREFIX
+
     # True when the runtime can `fork` (CRuby on a POSIX OS). On JRuby/TruffleRuby
     # and Windows it cannot — the caller must run the serial Runner instead.
     def self.available?
@@ -99,12 +105,16 @@ module Exwiw
 
       FileUtils.mkdir_p(@output_dir)
       parent = build_adapter
+      @counts = {}
 
       Dir.mktmpdir("exwiw-mongo-parallel-") do |sidecar_dir|
         phase1_leaf_and_genuine(parent, sidecar_dir)
         phase2_cascade(parent, sidecar_dir)
         phase3_ref_components(parent, sidecar_dir)
+        collect_counts(sidecar_dir)
       end
+
+      log_count_summary
 
       {
         workers: @workers,
@@ -112,6 +122,7 @@ module Exwiw
         leaves: @plan.leaves.size,
         ref_bt: @plan.ref_bt.size,
         components: @plan.reference_components.map(&:size).sort.reverse,
+        total_records: @counts.values.sum,
       }
     end
 
@@ -175,7 +186,7 @@ module Exwiw
       pids = groups.reject(&:empty?).map do |group|
         members = group.flatten
         seed = leaf_state.slice(*parents_of(members))
-        fork { run_component_worker(group, seed) }
+        fork { run_component_worker(group, seed, sidecar_dir) }
       end
       ok = pids.map { |pid| Process.wait(pid); $?.exitstatus&.zero? }.all?
       raise "exwiw parallel ref_bt pool failed" unless ok
@@ -204,25 +215,29 @@ module Exwiw
 
     def run_leaf_worker(group, sidecar_dir)
       adapter = build_adapter
-      group.each { |name| process_collection(adapter, name) }
+      counts = {}
+      group.each { |name| counts[name] = process_collection(adapter, name) }
       group.each do |name|
         next unless @plan.consumed_leaves.include?(name)
         next unless adapter.state.key?(name)
 
         File.binwrite(File.join(sidecar_dir, "#{name}.marshal"), Marshal.dump(adapter.state[name]))
       end
+      write_counts_sidecar(sidecar_dir, group.first, counts)
       exit!(0)
     rescue StandardError => e
       @logger.error("exwiw parallel leaf worker error (#{group.first}..): #{e.class}: #{e.message}")
       exit!(1)
     end
 
-    def run_component_worker(group, seed)
+    def run_component_worker(group, seed, sidecar_dir)
       adapter = build_adapter
       adapter.state = seed unless seed.empty?
       # Each component is already topologically ordered (parent before child) and
       # dependency-closed over intra-ref_bt edges, so a plain serial walk suffices.
-      group.each { |component| component.each { |name| process_collection(adapter, name) } }
+      counts = {}
+      group.each { |component| component.each { |name| counts[name] = process_collection(adapter, name) } }
+      write_counts_sidecar(sidecar_dir, group.first.first, counts)
       exit!(0)
     rescue StandardError => e
       @logger.error("exwiw parallel ref_bt worker error (#{group.first&.first}..): #{e.class}: #{e.message}")
@@ -266,6 +281,34 @@ module Exwiw
         path = File.join(sidecar_dir, "#{name}.marshal")
         state[name] = Marshal.load(File.binread(path)) if File.exist?(path)
       end
+    end
+
+    # Gather every collection's extracted record count back into the parent for the
+    # completion summary. genuine counts are already in @row_counts (parent-local,
+    # post-cascade); the leaf and ref_bt collections were extracted in forked
+    # workers, so each worker wrote a small Marshal counts sidecar (the same IPC
+    # pattern the consumed-leaf @state uses) that we merge here before the tmpdir is
+    # removed.
+    def collect_counts(sidecar_dir)
+      @counts.merge!(@row_counts)
+      Dir.glob(File.join(sidecar_dir, "#{COUNTS_SIDECAR_PREFIX}*.marshal")).each do |path|
+        @counts.merge!(Marshal.load(File.binread(path)))
+      end
+    end
+
+    def write_counts_sidecar(sidecar_dir, tag, counts)
+      File.binwrite(File.join(sidecar_dir, "#{COUNTS_SIDECAR_PREFIX}#{tag}.marshal"), Marshal.dump(counts))
+    end
+
+    # Log one line per extractable collection in the dump's processing order (the
+    # same order the insert-NNN- files are numbered), so the counts cross-reference
+    # directly with the output files. A collection that matched no rows shows 0
+    # (its output file was deleted).
+    def log_count_summary
+      total = @counts.values.sum
+      nonzero = @counts.count { |_, count| count.positive? }
+      @logger.info("Per-collection extracted record counts (#{total} record(s) across #{nonzero} collection(s)):")
+      @plan.extractable.each { |name| @logger.info("  #{name}: #{@counts.fetch(name, 0)}") }
     end
 
     # The distinct belongs_to parent names of `names`, used to slice the leaf @state


### PR DESCRIPTION
## 背景

MongoDB の `--parallel-workers` 並列ダンプは集計値（genuine/leaves/ref_bt の数）しかログに出さず、collection ごとに何件抽出したかが分からなかった。leaf / ref_bt は fork した子プロセスで抽出されるため、件数が親プロセスに戻ってこないのが原因。

各 worker が既存の Marshal sidecar IPC（consumed-leaf の `@state` 受け渡しと同じ仕組み）で件数を親に返し、完了時に `name: count` を処理順（`insert-NNN-` の採番順）で一覧ログ出力する。出力ファイルには一切触れないため byte-identity 保証は維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)