### PR TITLE
feat(mongodb): クエリ timeout を global + per-collection で設定可能に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **The mongodb adapter accepts a server-enforced query timeout, globally and per collection.** A global `--mongodb-query-timeout-ms=N` (also `mongodb_query_timeout_ms:` in the config file) sets the MongoDB driver's CSOT `timeout_ms` on the client, so every operation — the find cursor's whole lifetime (initial batch and every `getMore` the streaming dump walks), the document count, and an executing `explain` — is bounded; past the deadline the server aborts the operation and exwiw fails the run, so an accidentally heavy or unscoped query cannot keep pinning the (often production) source. A per-collection `query_timeout_ms` key in the schema config overrides the global for that collection's find/count (give a known-large collection more headroom, or cap a runaway one); like `bulk_insert_chunk_size`, it is user-maintained and preserved across Mongoid schema regeneration. Both are **mongodb-only** (the SQL adapters shell out to their own clients) and must be positive integers; the default is no timeout. The fork-parallel dump inherits both automatically (workers rebuild the client from the same connection config and run the same per-collection queries).
+
 ## [0.9.1] - 2026-06-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ insert_only: false
 after_insert_hook: hooks/seed.rb
 log_level: info              # debug | info
 # target_table / ids / ids_field / scope_column may also be set here
+# mongodb_query_timeout_ms: 30000   # global query timeout (mongodb only)
 ```
 
 With the file above, only the connection details need to be supplied on the CLI:
@@ -317,6 +318,7 @@ Notes:
 - Unknown keys are rejected so a typo surfaces immediately.
 - Export-only keys (`output_dir`, `output_format`, `insert_only`, `after_insert_hook`) are ignored when running `explain`, so a single config file can be shared by both subcommands.
 - `explain_verbosity` sets the mongodb `explain` verbosity (`queryPlanner` | `executionStats` | `allPlansExecution`, default `queryPlanner`); the `EXWIW_MONGODB_EXPLAIN_VERBOSITY` env var overrides it. Ignored by the SQL adapters and by `export`. See [`exwiw explain`](#mongodb-explain-verbosity).
+- `mongodb_query_timeout_ms` sets the global, server-enforced query timeout (mongodb only); the `--mongodb-query-timeout-ms` CLI flag overrides it. Ignored by the SQL adapters. See [MongoDB notes](#mongodb-notes).
 
 ### Generator
 
@@ -395,7 +397,7 @@ It is a distinct task and class (`Exwiw::MongoidSchemaGenerator`) from the Activ
 
 Models in an inheritance hierarchy whose subclasses share the base's collection (Mongoid STI, distinguished by the auto-added `_type` discriminator) collapse into a single config: the generator discovers the subclasses via `descendants` (Mongoid registers only the base class in `Mongoid.models`) and unions every class's `fields` and `belongs_tos` into the collection config, so subclass-only fields and associations are not lost.
 
-Regeneration preserves hand-edited `replace_with`, `filter`, `ignore`, and `bulk_insert_chunk_size` values, like the ActiveRecord generator. Indexes are not written to the config — they are introspected from the live database at dump time (see [MongoDB notes](#mongodb-notes)). Polymorphic `belongs_to` is not yet expanded by this task.
+Regeneration preserves hand-edited `replace_with`, `filter`, `ignore`, `bulk_insert_chunk_size`, and `query_timeout_ms` values, like the ActiveRecord generator. Indexes are not written to the config — they are introspected from the live database at dump time (see [MongoDB notes](#mongodb-notes)). Polymorphic `belongs_to` is not yet expanded by this task.
 
 By default the task **aborts** when a model uses a construct exwiw cannot represent: a `belongs_to` whose target class can no longer be resolved (a stale relation left behind after its model was removed), or a polymorphic / self-referential-cyclic / ambiguous / unresolvable-parent `embedded_in` (see the cases above).
 
@@ -800,6 +802,7 @@ The MongoDB adapter is experimental. To use it:
 - `--target-collection=COLLECTION` is a mongodb-only alias of `--target-table` (use whichever reads better for MongoDB). Specifying both, or using `--target-collection` with a non-mongodb adapter, is an error.
 - `--ids-field=FIELD` matches `--ids` against `FIELD` on the target collection instead of its primary key (e.g. `--target-collection=users --ids=a@example.com --ids-field=email`). Downstream foreign-key propagation still keys off the primary key, so only the target collection's filter changes. Unlike the primary-key path, the supplied ids are **not** type-coerced (the stored type of a custom field is unknown), so pass values matching the field's actual type. This flag is **mongodb-only** (the SQL adapters have no equivalent).
 - Large or embedded-document-heavy dumps are streamed automatically: the adapter reads the collection through a lazy cursor (not `.to_a`) and writes JSONL in chunks, so peak memory is bounded by the chunk size rather than the collection size — no flag to set. Encoding each document to MongoDB Extended JSON is accelerated by an **optional native (C) extension** that compiles automatically on `gem install`; where it cannot compile, exwiw falls back to a byte-identical pure-Ruby encoder. See [`docs/optimization-notes.md`](docs/optimization-notes.md) for the performance investigation and [`docs/optimize-mongodb-export-with-native-ext.md`](docs/optimize-mongodb-export-with-native-ext.md) for the native encoder's design. Benchmark your own data with `script/bench_mongodb_dump.rb`.
+- `--mongodb-query-timeout-ms=N` sets a global, **server-enforced** timeout (in milliseconds) on every query exwiw issues — the find cursor's whole lifetime (the initial batch and every `getMore` the streaming dump walks), the count, and an executing `explain`. Past the deadline the server aborts the operation and exwiw fails the run, so an accidentally heavy or unscoped query cannot keep pinning the (often production) source. It is **mongodb-only** (the SQL adapters shell out to their own clients) and may also be set as `mongodb_query_timeout_ms:` in the config file. The default is no timeout. A single collection can opt to a different limit with a `query_timeout_ms` key in its schema config (a sibling of `bulk_insert_chunk_size`), which overrides the global for that collection's find/count — use it to give a known-large collection more headroom, or to cap one that tends to run away. Hand-edited `query_timeout_ms` values are preserved across schema regeneration.
 - `--parallel-workers=N` (opt-in, `export` only) forks `N` worker processes that decode whole collections in parallel — the dominant cost on a large dump is the driver's BSON→Ruby decode, and each worker decodes its own collections in their natural order, so the output stays **byte-identical** to a serial run (same filenames and content). It needs a dump target (the schedule is built around the scoped DAG) and a `fork`-capable runtime (CRuby on POSIX), falling back to the serial path otherwise; it also accepts `parallel_workers:` in the config file. The speedup needs real cores to spend — it reaches ~2× from 4 workers and saturates there. The default is serial. See [`docs/mongodb-dump-parallelism-2x-notes.md`](docs/mongodb-dump-parallelism-2x-notes.md) for the schedule and measurements.
 - Output is JSON Lines (`insert-{idx}-{collection}.jsonl`) using MongoDB Extended JSON (relaxed mode). Import with `mongoimport`:
   ```bash

--- a/e2e/mongodb-parallel-schema/products.json
+++ b/e2e/mongodb-parallel-schema/products.json
@@ -1,6 +1,7 @@
 {
   "name": "products",
   "primary_key": "_id",
+  "query_timeout_ms": 45000,
   "belongs_tos": [{
     "table_name": "shops",
     "foreign_key": "shop_id"

--- a/e2e/mongodb-schema/users.json
+++ b/e2e/mongodb-schema/users.json
@@ -1,6 +1,7 @@
 {
   "name": "users",
   "primary_key": "_id",
+  "query_timeout_ms": 45000,
   "belongs_tos": [{
     "table_name": "shops",
     "foreign_key": "shop_id"

--- a/e2e/test_with_mongodb.sh
+++ b/e2e/test_with_mongodb.sh
@@ -20,6 +20,11 @@ bundle exec ruby e2e/setup_with_mongodb.rb "${FROM_DATABASE_NAME}"
 # server; the from-clean variant still covers the --host/--port path. The
 # database name is intentionally left out of the CLI and taken from the URI
 # path (mongodb://host:port/<db>) to verify it resolves from the URI.
+#
+# --mongodb-query-timeout-ms exercises the global, server-enforced query
+# timeout end-to-end (set generously so the tiny seed always finishes within
+# it). The per-collection override is exercised too: e2e/mongodb-schema/users.json
+# carries its own query_timeout_ms.
 bundle exec exe/exwiw \
   --adapter=mongodb \
   --uri="mongodb://${MONGO_HOST}:${MONGO_PORT}/${FROM_DATABASE_NAME}" \
@@ -27,6 +32,7 @@ bundle exec exe/exwiw \
   --target-table=shops \
   --ids=a00100000000000000000001 \
   --output-dir=tmp/mongodb \
+  --mongodb-query-timeout-ms=60000 \
   --log-level=debug
 
 # Import generated jsonl into target

--- a/e2e/test_with_mongodb_from_clean.sh
+++ b/e2e/test_with_mongodb_from_clean.sh
@@ -30,7 +30,10 @@ mongosh --quiet "mongodb://${MONGO_HOST}:${MONGO_PORT}/${TO_DATABASE_NAME}" \
 bundle exec ruby e2e/setup_with_mongodb.rb "${FROM_DATABASE_NAME}"
 
 # Run exwiw — output to a dedicated dir so we don't collide with the default
-# scenario's artifacts.
+# scenario's artifacts. --mongodb-query-timeout-ms also covers the global
+# timeout over the --host/--port client branch (the --uri branch is covered by
+# test_with_mongodb.sh); the per-collection override rides along via
+# e2e/mongodb-schema/users.json.
 bundle exec exe/exwiw \
   --adapter=mongodb \
   --host="${MONGO_HOST}" \
@@ -40,6 +43,7 @@ bundle exec exe/exwiw \
   --target-table=shops \
   --ids=a00100000000000000000001 \
   --output-dir=tmp/mongodb-clean \
+  --mongodb-query-timeout-ms=60000 \
   --log-level=debug
 
 # Apply insert-000-schema.js against the empty TO database. This must create

--- a/e2e/test_with_mongodb_parallel.sh
+++ b/e2e/test_with_mongodb_parallel.sh
@@ -41,12 +41,18 @@ rm -f "$SERIAL_DIR"/* "$PARALLEL_DIR"/*
 # Setup source db. Both dumps read the same (unmodified) source.
 bundle exec ruby e2e/setup_with_mongodb_parallel.rb "${FROM_DATABASE_NAME}"
 
+# --mongodb-query-timeout-ms is shared by both runs, so it keeps the output
+# byte-identical while proving the forked workers inherit the global timeout
+# (they rebuild the client from the same connection config). The per-collection
+# override rides along via e2e/mongodb-parallel-schema/products.json, exercising
+# query_timeout_ms threading through a collection processed in a fork worker.
 common_args=(
   --adapter=mongodb
   --uri="mongodb://${MONGO_HOST}:${MONGO_PORT}/${FROM_DATABASE_NAME}"
   --schema-dir=e2e/mongodb-parallel-schema
   --target-table=shops
   --ids=d00100000000000000000001
+  --mongodb-query-timeout-ms=60000
   --log-level=info
 )
 

--- a/lib/exwiw.rb
+++ b/lib/exwiw.rb
@@ -56,5 +56,13 @@ module Exwiw
   # mongodb adapter, e.g. `mongodb+srv://...`). When present it is the source of
   # truth for the connection — host/port/user/password are ignored — so TLS,
   # replica_set, auth_source, etc. can be expressed via the URI's query string.
-  ConnectionConfig = Struct.new(:adapter, :host, :port, :user, :password, :database_name, :uri, keyword_init: true)
+  #
+  # `mongodb_query_timeout_ms` is the global, server-enforced operation timeout
+  # (CSOT `timeout_ms`) applied to every MongoDB query exwiw issues — the find
+  # cursor's whole lifetime, the count, and an executing `explain`. It guards
+  # against an accidentally heavy/unscoped query pinning the (often production)
+  # source: the server aborts the operation past the deadline. nil leaves it
+  # unset (no timeout). A per-collection `query_timeout_ms` overrides it.
+  # mongodb adapter only.
+  ConnectionConfig = Struct.new(:adapter, :host, :port, :user, :password, :database_name, :uri, :mongodb_query_timeout_ms, keyword_init: true)
 end

--- a/lib/exwiw/adapter/mongodb_adapter.rb
+++ b/lib/exwiw/adapter/mongodb_adapter.rb
@@ -40,15 +40,20 @@ module Exwiw
       class StreamingResult
         include Enumerable
 
-        def initialize(view:, collection:, keys:, state:)
+        def initialize(view:, collection:, keys:, state:, timeout_ms: nil)
           @view = view
           @collection = collection
           @keys = keys
           @state = state
+          @timeout_ms = timeout_ms
         end
 
         def size
-          @size ||= @view.count_documents
+          # count_documents reads :timeout_ms only from the opts passed here (it
+          # does not inherit the find view's per-op timeout), so the per-collection
+          # value must be threaded in explicitly. When nil it falls back to the
+          # client-wide global timeout, like every other operation.
+          @size ||= @timeout_ms ? @view.count_documents(timeout_ms: @timeout_ms) : @view.count_documents
         end
         alias length size
 
@@ -172,6 +177,7 @@ module Exwiw
           primary_key: config.primary_key,
           filter: filter,
           projection: build_projection(config, @propagation_keys),
+          timeout_ms: config.query_timeout_ms,
         )
       end
 
@@ -179,7 +185,7 @@ module Exwiw
         @logger.debug("  Executing Mongo find on '#{query.collection}': filter=#{query.filter.inspect} projection=#{query.projection.inspect}")
 
         view = db[query.collection]
-          .find(query.filter)
+          .find(query.filter, find_timeout_opts(query))
           .projection(query.projection)
           .comment(query_comment_text("collection=#{query.collection}"))
 
@@ -195,7 +201,7 @@ module Exwiw
         # large / embed-heavy collections — the dump's dominant memory cost. The
         # propagation-key values are captured as the cursor streams and published
         # into @state once the pass completes (see StreamingResult).
-        StreamingResult.new(view: view, collection: query.collection, keys: keys, state: @state)
+        StreamingResult.new(view: view, collection: query.collection, keys: keys, state: @state, timeout_ms: query.timeout_ms)
       end
 
       # NOTE: relies on @embedded_children_by_parent set by a prior build_query
@@ -233,7 +239,7 @@ module Exwiw
         @logger.debug("  Running explain (verbosity=#{verbosity}) on '#{query.collection}': filter=#{query.filter.inspect}")
 
         result = db[query.collection]
-          .find(query.filter)
+          .find(query.filter, find_timeout_opts(query))
           .projection(query.projection)
           .comment(query_comment_text("collection=#{query.collection}"))
           .explain(verbosity: verbosity)
@@ -358,6 +364,16 @@ module Exwiw
         ::BSON::ObjectId.legal?(str)
       rescue LoadError
         false
+      end
+
+      # Per-operation find options carrying the collection's CSOT timeout. An
+      # empty hash when the query has none, so the operation inherits the
+      # client-wide global timeout (or runs untimed if that is also unset). The
+      # find view's :timeout_ms governs the whole cursor lifetime — initial batch
+      # plus every getMore the streaming dump walks — which is what makes it the
+      # right cap for an accidentally heavy/unscoped extraction.
+      private def find_timeout_opts(query)
+        query.timeout_ms ? { timeout_ms: query.timeout_ms } : {}
       end
 
       private def reject_filter!(config)
@@ -670,14 +686,14 @@ module Exwiw
               # given, overrides the database in the URI path; otherwise the
               # URI's own database is used. The URI is never logged (it may carry
               # credentials).
-              client_options = {}
+              client_options = global_timeout_options
               if @connection_config.database_name && !@connection_config.database_name.to_s.empty?
                 client_options[:database] = @connection_config.database_name
               end
               Mongo::Client.new(@connection_config.uri, **client_options)
             else
               address = "#{@connection_config.host}:#{@connection_config.port}"
-              options = { database: @connection_config.database_name }
+              options = global_timeout_options.merge(database: @connection_config.database_name)
               if @connection_config.user && !@connection_config.user.to_s.empty?
                 options[:user] = @connection_config.user
                 options[:password] = @connection_config.password
@@ -689,6 +705,15 @@ module Exwiw
 
       private def uri_connection?
         !@connection_config.uri.nil? && !@connection_config.uri.to_s.empty?
+      end
+
+      # Client-level CSOT default applied to every operation on this connection
+      # (find cursor lifetime, count, executing explain). nil when no global
+      # timeout is configured, leaving the client untimed; a per-collection
+      # `query_timeout_ms` still overrides this per find/count.
+      private def global_timeout_options
+        timeout = @connection_config.mongodb_query_timeout_ms
+        timeout ? { timeout_ms: timeout } : {}
       end
     end
   end

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -37,6 +37,7 @@ module Exwiw
       scope_column
       parallel_workers
       explain_verbosity
+      mongodb_query_timeout_ms
     ].freeze
 
     # MongoDB explain verbosity levels (passed through to the server's explain
@@ -89,6 +90,7 @@ module Exwiw
       @insert_only = nil
       @after_insert_hook_path = nil
       @parallel_workers = nil
+      @mongodb_query_timeout_ms = nil
       @explain_verbosity = nil
       # nil (not :info) so we can tell "user passed --log-level" from the default,
       # letting a config-file value fill in; the :info default is applied later.
@@ -113,6 +115,7 @@ module Exwiw
         password: @database_password,
         database_name: @database_name,
         uri: @connection_uri,
+        mongodb_query_timeout_ms: @mongodb_query_timeout_ms,
       )
 
       dump_target = DumpTarget.new(
@@ -178,6 +181,7 @@ module Exwiw
       resolve_ids_field!
       resolve_uri_option!
       resolve_parallel_workers!
+      resolve_mongodb_query_timeout_ms!
 
       if @subcommand == "explain"
         validate_explain_only!
@@ -331,6 +335,7 @@ module Exwiw
       @ids_field ||= config["ids_field"]
       @scope_column ||= config["scope_column"]
       @parallel_workers ||= parse_parallel_workers(config["parallel_workers"]) if config.key?("parallel_workers")
+      @mongodb_query_timeout_ms ||= parse_mongodb_query_timeout_ms(config["mongodb_query_timeout_ms"]) if config.key?("mongodb_query_timeout_ms")
       @explain_verbosity ||= config["explain_verbosity"]
     end
 
@@ -454,6 +459,38 @@ module Exwiw
       Integer(value)
     rescue ArgumentError, TypeError
       $stderr.puts "config 'parallel_workers' must be an integer (got #{value.inspect})"
+      exit 1
+    end
+
+    # `--mongodb-query-timeout-ms` sets the global, server-enforced CSOT timeout
+    # applied to every MongoDB query (find cursor lifetime, count, executing
+    # explain). It is mongodb-only (the SQL adapters shell out to their own
+    # clients) and must be a positive integer. A per-collection `query_timeout_ms`
+    # in the schema config overrides it. Runs after the adapter name is normalized
+    # so the family check is reliable.
+    private def resolve_mongodb_query_timeout_ms!
+      return if @mongodb_query_timeout_ms.nil?
+
+      if @database_adapter != "mongodb"
+        $stderr.puts "--mongodb-query-timeout-ms is only supported by the mongodb adapter"
+        exit 1
+      end
+
+      if @mongodb_query_timeout_ms < 1
+        $stderr.puts "--mongodb-query-timeout-ms must be a positive integer (got #{@mongodb_query_timeout_ms})"
+        exit 1
+      end
+    end
+
+    # Coerce a config-file `mongodb_query_timeout_ms` (YAML scalar) to Integer,
+    # matching the CLI flag's Integer coercion. A non-integer value is a config
+    # typo, so fail fast rather than silently dropping it.
+    private def parse_mongodb_query_timeout_ms(value)
+      return nil if value.nil?
+
+      Integer(value)
+    rescue ArgumentError, TypeError
+      $stderr.puts "config 'mongodb_query_timeout_ms' must be an integer (got #{value.inspect})"
       exit 1
     end
 
@@ -591,6 +628,7 @@ module Exwiw
           @after_insert_hook_path = File.expand_path(v)
         end
         opts.on("--parallel-workers=N", Integer, "Fork N workers for the MongoDB dump's parallel schedule (mongodb + export only; N>=2 enables it, default is serial). Output is byte-identical to serial; falls back to serial where fork is unavailable.") { |v| @parallel_workers = v }
+        opts.on("--mongodb-query-timeout-ms=N", Integer, "Global server-enforced timeout (ms) for every MongoDB query (mongodb only). Aborts an accidentally heavy/unscoped query past the deadline. Overridden per collection by `query_timeout_ms` in the schema config.") { |v| @mongodb_query_timeout_ms = v }
         opts.on("--log-level=LEVEL", "Log level (debug, info). default is info") { |v| @log_level = v.to_sym }
 
         opts.on("--help", "Print this help") do

--- a/lib/exwiw/mongo_query.rb
+++ b/lib/exwiw/mongo_query.rb
@@ -2,14 +2,19 @@
 
 module Exwiw
   module MongoQuery
-    Find = Struct.new(:collection, :primary_key, :filter, :projection, keyword_init: true) do
+    # `timeout_ms` is the per-collection, server-enforced operation timeout (CSOT)
+    # applied when this query runs; nil falls back to the client-wide global
+    # (ConnectionConfig#mongodb_query_timeout_ms) or, if that is also unset, no
+    # timeout. Omitted from #to_h when nil so the historical 4-key query shape is
+    # unchanged for collections without a timeout.
+    Find = Struct.new(:collection, :primary_key, :filter, :projection, :timeout_ms, keyword_init: true) do
       def to_h
         {
           collection: collection,
           primary_key: primary_key,
           filter: filter,
           projection: projection,
-        }
+        }.tap { |h| h[:timeout_ms] = timeout_ms unless timeout_ms.nil? }
       end
     end
   end

--- a/lib/exwiw/mongodb_collection_config.rb
+++ b/lib/exwiw/mongodb_collection_config.rb
@@ -13,6 +13,13 @@ module Exwiw
     attribute :belongs_tos, array(BelongsTo)
     attribute :fields, array(MongodbField)
     attribute :bulk_insert_chunk_size, optional(Integer), skip_serializing_if_nil: true
+    # Per-collection server-enforced query timeout in milliseconds (CSOT). Applied
+    # to this collection's find (whole cursor lifetime), count, and an executing
+    # explain; overrides the global ConnectionConfig#mongodb_query_timeout_ms. Use
+    # it to give a known-large collection more headroom than the global default
+    # (or, conversely, to cap one that tends to run away). User-maintained — the
+    # generator never emits it, so #merge carries it forward across regeneration.
+    attribute :query_timeout_ms, optional(Integer), skip_serializing_if_nil: true
     attribute :ignore, Serdes::OptionalType.new(Serdes::ConcreteType.new(Boolean)), skip_serializing_if_nil: true
     # Free-form note. Purely informational — exwiw never reads it — and preserved
     # across `MongoidSchemaGenerator` regeneration like the field / belongs_to
@@ -62,7 +69,8 @@ module Exwiw
     # - structural facts come from the freshly generated config: primary_key,
     #   belongs_tos, embedded_in.
     # - user customizations are kept from the receiver: filter, ignore,
-    #   bulk_insert_chunk_size, and each field's `replace_with` masking rule.
+    #   bulk_insert_chunk_size, query_timeout_ms, and each field's `replace_with`
+    #   masking rule.
     # - generated fields drive the field list (so added/removed fields track the
     #   model), but a matching receiver field wins to retain its masking.
     def merge(passed)
@@ -73,6 +81,7 @@ module Exwiw
         merged.primary_key = passed.primary_key
         merged.filter = filter
         merged.bulk_insert_chunk_size = bulk_insert_chunk_size
+        merged.query_timeout_ms = query_timeout_ms
         merged.ignore = ignore
         merged.ignore_type = ignore_type
         # A freshly generated comment (e.g. the skip_unsupported marker) wins so

--- a/spec/adapter/mongodb_adapter_spec.rb
+++ b/spec/adapter/mongodb_adapter_spec.rb
@@ -70,6 +70,21 @@ module Exwiw
               projection: { "_id" => 1, "name" => 1, "updated_at" => 1, "created_at" => 1 },
             )
           end
+
+          it "leaves timeout_ms nil and omits it from to_h when the collection sets none" do
+            shops = config_by_name.fetch("shops")
+            query = adapter.build_query(shops, dump_target, config_by_name)
+            expect(query.timeout_ms).to be_nil
+            expect(query.to_h).not_to have_key(:timeout_ms)
+          end
+
+          it "carries the collection's query_timeout_ms onto the query (and into to_h)" do
+            shops = config_by_name.fetch("shops")
+            shops.query_timeout_ms = 45_000
+            query = adapter.build_query(shops, dump_target, config_by_name)
+            expect(query.timeout_ms).to eq(45_000)
+            expect(query.to_h).to include(timeout_ms: 45_000)
+          end
         end
 
         context "when dump_target.ids_field overrides the filter field" do
@@ -378,6 +393,29 @@ module Exwiw
 
             expect(users.size).to eq(2)
             expect(users.map { |u| u["shop_id"] }.uniq).to eq([shop1_oid])
+          end
+        end
+
+        context "when the collection sets a per-collection query_timeout_ms" do
+          let(:dump_target) { Exwiw::DumpTarget.new(table_name: "shops", ids: ["a00100000000000000000001"]) }
+
+          it "passes timeout_ms to both the find and the count operations" do
+            shops = config_by_name.fetch("shops")
+            shops.query_timeout_ms = 12_345
+            query = adapter.build_query(shops, dump_target, config_by_name)
+
+            view = double("view")
+            allow(view).to receive(:projection).and_return(view)
+            allow(view).to receive(:comment).and_return(view)
+            allow(view).to receive(:each)
+            expect(view).to receive(:count_documents).with({ timeout_ms: 12_345 }).and_return(0)
+            collection = double("collection")
+            expect(collection).to receive(:find).with(query.filter, { timeout_ms: 12_345 }).and_return(view)
+            allow(adapter).to receive(:db).and_return({ "shops" => collection })
+
+            result = adapter.execute(query)
+            result.size # triggers count_documents
+            result.to_a # triggers the streaming each
           end
         end
       end
@@ -723,6 +761,33 @@ module Exwiw
           client = double('client')
           expect(Mongo::Client).to receive(:new)
             .with(['db.example.com:27017'], database: 'app')
+            .and_return(client)
+          expect(adapter_for(config).send(:db)).to eq(client)
+        end
+
+        it "passes the global mongodb_query_timeout_ms as the client-wide CSOT timeout (host:port)" do
+          config = ConnectionConfig.new(
+            adapter: 'mongodb', host: 'db.example.com', port: 27017,
+            database_name: 'app', user: nil, password: nil, uri: nil,
+            mongodb_query_timeout_ms: 30_000,
+          )
+          client = double('client')
+          expect(Mongo::Client).to receive(:new)
+            .with(['db.example.com:27017'], timeout_ms: 30_000, database: 'app')
+            .and_return(client)
+          expect(adapter_for(config).send(:db)).to eq(client)
+        end
+
+        it "passes the global mongodb_query_timeout_ms alongside the URI" do
+          config = ConnectionConfig.new(
+            adapter: 'mongodb',
+            uri: 'mongodb+srv://u:p@cluster.example.com/app',
+            database_name: nil,
+            mongodb_query_timeout_ms: 30_000,
+          )
+          client = double('client')
+          expect(Mongo::Client).to receive(:new)
+            .with('mongodb+srv://u:p@cluster.example.com/app', timeout_ms: 30_000)
             .and_return(client)
           expect(adapter_for(config).send(:db)).to eq(client)
         end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -295,6 +295,49 @@ module Exwiw
       end
     end
 
+    describe '--mongodb-query-timeout-ms validation' do
+      def run_cli(argv)
+        CLI.new(argv).run
+      end
+
+      it 'parses --mongodb-query-timeout-ms into the ivar for the mongodb adapter' do
+        cli = CLI.new(['--adapter=mongodb', '--host=localhost', '--port=27017', '--database=app',
+                       '--schema-dir=e2e/mongodb-schema', '--target-collection=users', '--ids=1',
+                       '--mongodb-query-timeout-ms=30000'])
+        cli.send(:validate_options!)
+        expect(cli.instance_variable_get(:@mongodb_query_timeout_ms)).to eq(30000)
+      end
+
+      it 'rejects --mongodb-query-timeout-ms for non-mongodb adapters' do
+        argv = ['--adapter=sqlite', '--database=tmp/test.sqlite3', '--schema-dir=e2e/sqlite-schema',
+                '--target-table=users', '--ids=1', '--mongodb-query-timeout-ms=30000']
+        expect { run_cli(argv) }.to raise_error(SystemExit)
+          .and output(/--mongodb-query-timeout-ms is only supported by the mongodb adapter/).to_stderr
+      end
+
+      it 'rejects a non-positive --mongodb-query-timeout-ms' do
+        argv = ['--adapter=mongodb', '--host=localhost', '--port=27017', '--database=app',
+                '--schema-dir=e2e/mongodb-schema', '--target-collection=users', '--ids=1',
+                '--mongodb-query-timeout-ms=0']
+        expect { run_cli(argv) }.to raise_error(SystemExit)
+          .and output(/--mongodb-query-timeout-ms must be a positive integer/).to_stderr
+      end
+
+      it 'flows the parsed value into the ConnectionConfig' do
+        cli = CLI.new(['--adapter=mongodb', '--host=localhost', '--port=27017', '--database=app',
+                       '--schema-dir=e2e/mongodb-schema', '--target-collection=users', '--ids=1',
+                       '--mongodb-query-timeout-ms=30000'])
+        captured = nil
+        allow(Runner).to receive(:new) do |**kwargs|
+          captured = kwargs[:connection_config]
+          instance_double(Runner, run: nil)
+        end
+        allow($stdin).to receive(:tty?).and_return(false)
+        cli.run
+        expect(captured.mongodb_query_timeout_ms).to eq(30000)
+      end
+    end
+
     describe 'output dir clear confirmation' do
       around do |example|
         Dir.mktmpdir do |dir|

--- a/spec/mongodb_collection_config_spec.rb
+++ b/spec/mongodb_collection_config_spec.rb
@@ -217,6 +217,26 @@ module Exwiw
         expect(token.to_hash).to eq({ 'name' => 'token', 'replace_with' => 'X', 'comment' => 'secret', 'ignore' => true })
         expect(merged.fields.map(&:name)).to eq(['_id', 'token', 'extra'])
       end
+
+      it 'carries the user-owned query_timeout_ms forward (the generator never emits it)' do
+        current.query_timeout_ms = 120_000
+        merged = current.merge(passed)
+        expect(merged.query_timeout_ms).to eq(120_000)
+      end
+    end
+
+    describe 'query_timeout_ms serialization' do
+      it 'round-trips when set and is omitted from the hash when nil' do
+        with_timeout = described_class.from_symbol_keys(
+          name: 'orders', primary_key: '_id', belongs_tos: [], fields: [], query_timeout_ms: 90_000,
+        )
+        expect(with_timeout.to_hash).to include('query_timeout_ms' => 90_000)
+
+        without_timeout = described_class.from_symbol_keys(
+          name: 'orders', primary_key: '_id', belongs_tos: [], fields: [],
+        )
+        expect(without_timeout.to_hash).not_to have_key('query_timeout_ms')
+      end
     end
 
     describe '#reject_ignored_members!' do


### PR DESCRIPTION
## 背景

意図せず高負荷/未スコープなクエリ（full COLLSCAN 等）を本番 MongoDB に投げてしまったとき、サーバ側で打ち切る手段がなかった。

## 内容

サーバ側強制の CSOT `timeout_ms` を追加し、global + per-collection で設定可能にした。

- global: `--mongodb-query-timeout-ms=N` / config `mongodb_query_timeout_ms`
- per-collection: schema の `query_timeout_ms`（global を上書き）
- timeout 発火時は run 全体を失敗（fail-fast）
- find cursor 全体・count・実行を伴う explain に適用。fork-parallel dump も自動継承

🤖 Generated with [Claude Code](https://claude.com/claude-code)