### PR TITLE
fix(cli): STDOUT が pipe のとき進捗ログをリアルタイムに flush する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Progress logs now flush in real time when stdout is a pipe.** The CLI logger writes to `STDOUT`, which Ruby block-buffers when stdout is not a TTY (e.g. captured by a parent process or shipped to log aggregation), so a long `export`/`explain` surfaced its per-collection progress (`Processing table '...' (i/n)`, `Generated INSERT statement for N records`) only when the buffer filled or the process exited — reading as a stall. The CLI now sets `STDOUT.sync = true` before building the logger so each line flushes immediately. Data output is written to files (not stdout), so this does not affect dump throughput.
+
 ## [0.9.2] - 2026-06-30
 
 ### Added

--- a/lib/exwiw/cli.rb
+++ b/lib/exwiw/cli.rb
@@ -575,6 +575,12 @@ module Exwiw
         "#{formatted_ts} [#{progname}]: #{msg}\n"
       end
 
+      # When STDOUT is a pipe (captured by a parent process / log aggregation),
+      # Logger.new(STDOUT) is block-buffered, so per-collection progress only
+      # surfaces when the buffer fills or the process exits. Sync so each log
+      # line flushes immediately and progress is visible in real time.
+      STDOUT.sync = true
+
       Logger.new(
         STDOUT,
         level: @log_level,

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -32,6 +32,27 @@ module Exwiw
       end
     end
 
+    describe '#build_logger' do
+      # build_logger flips STDOUT.sync so piped/redirected progress logs are not
+      # block-buffered. Restore the flag so it does not leak into other specs.
+      around do |example|
+        original_sync = STDOUT.sync
+        example.run
+      ensure
+        STDOUT.sync = original_sync
+      end
+
+      it 'enables STDOUT sync so per-collection progress flushes in real time' do
+        cli = CLI.new(['--adapter=sqlite', '--database=tmp/test.sqlite3',
+                       '--schema-dir=e2e/sqlite-schema', '--log-level=info'])
+        STDOUT.sync = false
+
+        cli.send(:build_logger)
+
+        expect(STDOUT.sync).to be(true)
+      end
+    end
+
     describe 'explain subcommand validation' do
       def run_cli(argv)
         CLI.new(argv).run


### PR DESCRIPTION
## 背景

CLI の logger は `STDOUT` に書き込むが、STDOUT が TTY でない（親プロセスにキャプチャされる・ログ基盤に転送される等）とき Ruby がブロックバッファリングするため、長時間の `export`/`explain` の per-collection 進捗ログ（`Processing table ...` 等）が buffer が埋まるかプロセス終了まで出力されず、stall しているように見えていた。

## 変更

logger 構築前に `STDOUT.sync = true` を設定し各ログ行を即時 flush する。データ出力はファイルに書かれるため dump スループットには影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)